### PR TITLE
MOSIP-12434

### DIFF
--- a/partner/policy-management-service/src/main/java/io/mosip/pms/policy/service/PolicyManagementService.java
+++ b/partner/policy-management-service/src/main/java/io/mosip/pms/policy/service/PolicyManagementService.java
@@ -518,6 +518,7 @@ public class PolicyManagementService {
 		authPolicyH.setDescr(authPolicy.getDescr());
 		authPolicyH.setId(PolicyUtil.generateId());
 		authPolicyH.setIsActive(authPolicy.getIsActive());
+		authPolicyH.setIsDeleted(authPolicy.getIsDeleted());
 		authPolicyH.setName(authPolicy.getName());
 		authPolicyH.setPolicyFileId(authPolicy.getPolicyFileId());
 		authPolicyH.setUpdBy(authPolicy.getUpdBy());


### PR DESCRIPTION
While creating policy, isDeleted is going as NULL. But in db is_Deleted flag is not null.