### PR TITLE
MOSIP-36424 Automated negative test cases for PMS

### DIFF
--- a/api-test/src/main/resources/pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios.hbs
+++ b/api-test/src/main/resources/pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios.hbs
@@ -1,0 +1,12 @@
+{  
+"id": "{{id}}",
+  "version": "{{version}}",
+  "metadata": {},
+  "deviceDetailId": "{{deviceDetailId}}",
+  "requestTime": "{{requestTime}}",
+  "request": {
+    "partnerId": "{{partnerId}}",
+    "sbiId": "{{sbiId}}",
+    "status": "approved"
+  }
+}

--- a/api-test/src/main/resources/pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios.yml
+++ b/api-test/src/main/resources/pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios.yml
@@ -1,0 +1,311 @@
+ApproveMappingDeviceToSbiNegativeScenarios:
+   Pms_ApproveMappingDeviceToSbi_different_deviceDetails_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_01
+      description: Approve mapping device to sbi with different deviceDetails
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+      "version": "1.0",		
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "34242"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_006"
+       }
+       ]
+}'
+   Pms_ApproveMappingDeviceToSbi_without_SBI_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_02
+      description: Approve mapping device to sbi without without sbiId value
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbi
+      outputTemplate: pms/error
+      input: '{
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProvider_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_005"
+       }
+       ]
+}'
+   Pms_ApproveMappingDeviceToSbi_without_Req_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_03
+      description: Approve mapping device to sbi without Request ID
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "$REMOVE$",
+      "version": "1.0",
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProvider_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_002"
+       }
+       ]
+}'
+   Pms_ApproveMappingDeviceToSbi_without_Version_value_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_04
+      description: Approve mapping device to sbi without Version value
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+      "version": "$REMOVE$",
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProvider_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_003"
+       }
+       ]
+}'
+   Pms_ApproveMappingDeviceToSbi_without_deviceProviderID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_05
+      description: Approve mapping device to sbi without Device provider Id
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+      "version": "1.0",
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProvider_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_002"
+       }
+       ]
+}'
+   Pms_ApproveMappingDeviceToSbi_with_random_DeviceProviderID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_06
+      description: Approve mapping device to sbi with randome Device provider Id
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+      "version": "1.0",
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "deivce-sunny",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProvider_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_002"
+       }
+       ]
+}'
+   Pms_ApproveMappingDeviceToSbi_without_RequestTime_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_07
+      description: Approve mapping device to sbi without requestTime
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+      "version": "1.0",
+      "requestTime": "$REMOVE$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProvider_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_004"
+       }
+       ]
+}'
+   Pms_ApproveMappingDeviceToSbi_with_missing_SBIID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_08
+      description: Approve mapping device to sbi while keeping SBI ID parameter as missing
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+      "version": "1.0",
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$REMOVE$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProvider_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_024"
+       }
+       ]
+}'
+   Pms_ApproveMappingDeviceToSbi_which_is_already_approved_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_09
+      description: Approve mapping device to sbi by providing parameters which are already approved
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+      "version": "1.0",
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProvider_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_010"
+       }
+       ]
+}'
+   Pms_ApproveMappingDeviceToSbi_with_Invalid_DeviceID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_10
+      description: Approve mapping device to sbi by providing invalid Device ID
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+      "version": "1.0",
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$7372882$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_006"
+       }
+       ]
+}'
+   Pms_ApproveMappingDeviceToSbi_with_Invalid_SBIID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_11
+      description: Approve mapping device to sbi by providing invalid SBI ID
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+      "version": "1.0",
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "84838772",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProvider_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_005"
+       }
+       ]
+}'
+   Pms_ApproveMappingDeviceToSbi_without_Partner_Authentication_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_12
+      description: Approve mapping device to sbi without Partner Authentication
+      role: invalidtoken
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+      "version": "1.0",
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProvider_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "KER-ATH-401"
+       }
+       ]
+}'
+   Pms_ApproveMappingDeviceToSbi_with_Invalid_Partner_Authentication_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_ApproveMappingDeviceToSbiNegativeScenarios_13
+      description: Approve mapping device to sbi with Invalid Partner Authentication
+      role: invalidtoken
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+      "version": "1.0",
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProvider_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "KER-ATH-401"
+       }
+       ]
+}'

--- a/api-test/src/main/resources/pms/DeactivateSBIWithAssociatedDevices/DeactivateSBIWithAssociatedDevices.yml
+++ b/api-test/src/main/resources/pms/DeactivateSBIWithAssociatedDevices/DeactivateSBIWithAssociatedDevices.yml
@@ -1,6 +1,8 @@
 DeactivateSBIWithAssociatedDevices:
    Pms_DeactivateSBIWithAssociatedDevices_all_Valid_Smoke_sid:
       endPoint: /v1/partnermanager/securebiometricinterface/{sbiId}
+      uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_01
+      description: Deactivate SBI along with Associated Devices
       role: partnerdevice
       checkErrorsOnlyInResponse: true
       restMethod: patch

--- a/api-test/src/main/resources/pms/DeactivateSBIWithAssociatedDevices/DeactivateSBIWithAssociatedDevicesNegativeScenarios.yml
+++ b/api-test/src/main/resources/pms/DeactivateSBIWithAssociatedDevices/DeactivateSBIWithAssociatedDevicesNegativeScenarios.yml
@@ -213,7 +213,7 @@ DeactivateSBIWithAssociatedDevicesNegativeScenarios:
        }
        ]
 }'
-   Pms_DeactivateSBIWithAssociatedDevices_Invalid_VersionValue_Neg:
+   Pms_DeactivateSBIWithAssociatedDevices_Invalid_VersionValue1_Neg:
       endPoint: /v1/partnermanager/securebiometricinterface/{sbiId}
       uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_11
       description: Deactivate SBI while keeping Version parameter as invalid value 1 in request
@@ -235,7 +235,7 @@ DeactivateSBIWithAssociatedDevicesNegativeScenarios:
        }
        ]
 }'
-   Pms_DeactivateSBIWithAssociatedDevices_Invalid_VersionValue_Neg:
+   Pms_DeactivateSBIWithAssociatedDevices_Invalid_VersionValue0_Neg:
       endPoint: /v1/partnermanager/securebiometricinterface/{sbiId}
       uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_12
       description: Deactivate SBI while keeping Version parameter as invalid value 0 in request
@@ -304,7 +304,7 @@ DeactivateSBIWithAssociatedDevicesNegativeScenarios:
 
    Pms_DeactivateSBIWithAssociatedDevices_Already_deactivated_SBI_Neg:
       endPoint: /v1/partnermanager/securebiometricinterface/{sbiId}
-      uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_16
+      uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_15
       description: Deactivate SBI which already Deactivated in request
       role: partnerdevice
       checkErrorsOnlyInResponse: true
@@ -324,7 +324,7 @@ DeactivateSBIWithAssociatedDevicesNegativeScenarios:
 }'
    Pms_DeactivateSBIWithAssociatedDevices_Null_SBI_ID_Neg:
       endPoint: /v1/partnermanager/securebiometricinterface/{sbiId}
-      uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_17
+      uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_16
       description: Deactivate SBI while keeping SBI ID parameter as Null in request
       role: partnerdevice
       checkErrorsOnlyInResponse: true
@@ -346,7 +346,7 @@ DeactivateSBIWithAssociatedDevicesNegativeScenarios:
 }'
    Pms_DeactivateSBIWithAssociatedDevices_Empty_SBI_ID_Neg:
       endPoint: /v1/partnermanager/securebiometricinterface/{sbiId}
-      uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_18
+      uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_17
       description: Deactivate SBI while keeping SBI ID parameter as Empty in request
       role: partnerdevice
       checkErrorsOnlyInResponse: true
@@ -368,7 +368,7 @@ DeactivateSBIWithAssociatedDevicesNegativeScenarios:
 }'
    Pms_DeactivateSBIWithAssociatedDevices_InvalidNumeric_SBI_ID_Neg:
       endPoint: /v1/partnermanager/securebiometricinterface/{sbiId}
-      uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_19
+      uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_18
       description: Deactivate SBI while keeping SBI ID parameter as Invalid Numeric values in request
       role: partnerdevice
       checkErrorsOnlyInResponse: true
@@ -390,7 +390,7 @@ DeactivateSBIWithAssociatedDevicesNegativeScenarios:
 }'
    Pms_DeactivateSBIWithAssociatedDevices_Invalid_SBI_ID_Neg:
       endPoint: /v1/partnermanager/securebiometricinterface/{sbiId}
-      uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_20
+      uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_19
       description: Deactivate SBI while keeping SBI ID parameter as Invalid values in request
       role: partnerdevice
       checkErrorsOnlyInResponse: true
@@ -407,6 +407,28 @@ DeactivateSBIWithAssociatedDevicesNegativeScenarios:
       "errors": [
       {
        "errorCode": "PMS_DEVICE_ERROR_005"
+       }
+       ]
+}'
+   Pms_DeactivateSBIWithAssociatedDevices_with_invalid_roles_Neg:
+      endPoint: /v1/partnermanager/securebiometricinterface/{sbiId}
+      uniqueIdentifier: TC_PMS_DeactivateSBIWithAssociatedDevices_20
+      description: Deactivate SBI with invalid Partner roles
+      role: device
+      checkErrorsOnlyInResponse: true
+      restMethod: patch
+      inputTemplate: pms/DeactivateSBIWithAssociatedDevices/DeactivateSBIWithAssociatedDevicesNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.deactivate.sbi.patch",
+      "version": "1.0",
+      "requesttime": "$TIMESTAMP$",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+      "errors": [
+      {
+       "errorCode": "KER-ATH-403"
        }
        ]
 }'

--- a/api-test/src/main/resources/pms/GetAllApprovedDeviceProviderIds/GetAllApprovedDeviceProviderIdsNegativeScenarios.yml
+++ b/api-test/src/main/resources/pms/GetAllApprovedDeviceProviderIds/GetAllApprovedDeviceProviderIdsNegativeScenarios.yml
@@ -33,3 +33,20 @@ GetAllApprovedDeviceProviderIdsNegativeScenarios:
        }
        ]
 }'
+   Pms_GetAllApprovedDeviceProviderIds_without_partner_roles_Neg:
+      endPoint: /v1/partnermanager/partners/v3?status=approved&partnerType=Device_Provider
+      uniqueIdentifier: TC_PMS_GetAllApprovedDeviceProviderIds_03
+      description: Retrieve All Approved Device ProviderIds without_partner_roles
+      role: device
+      restMethod: get
+      inputTemplate: pms/GetAllApprovedDeviceProviderIds/GetAllApprovedDeviceProviderIds
+      outputTemplate: pms/error
+      input: '{
+}'
+      output: '{
+      "errors": [
+      {
+       "errorCode": "KER-ATH-403"
+       }
+       ]
+}'

--- a/api-test/src/main/resources/pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios.hbs
+++ b/api-test/src/main/resources/pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios.hbs
@@ -1,0 +1,12 @@
+{
+  "id": "{{id}}",
+  "version": "{{version}}",
+  "metadata": {},
+  "deviceDetailId": "{{deviceDetailId}}",
+  "requestTime": "{{requestTime}}",
+  "request": {
+    "partnerId": "{{partnerId}}",
+    "sbiId": "{{sbiId}}",
+    "status": "rejected"
+  }
+}

--- a/api-test/src/main/resources/pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios.yml
+++ b/api-test/src/main/resources/pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios.yml
@@ -1,0 +1,721 @@
+RejectMappingDeviceToSbiNegativeScenarios:
+   Pms_RejectMappingDeviceToSbi_without_Partner_Auth_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_01
+      description: Reject mapping device to sbi without Partner Authentication and expecting an error in response
+      role: invalidtoken
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.reject.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "KER-ATH-401"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Missing_Req_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_02
+      description: Reject mapping device to sbi while passing Invalid RequestID parameter in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "$REMOVE$",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_002"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSb_ReqID_Null_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_03
+      description: Reject mapping device to sbi while keeping ReqID parameter as Null in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "null",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_002"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_ReqID_Empty_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_04
+      description: Reject mapping device to sbi while keeping ReqID parameter as Empty in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_002"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_ReqID_Invalid_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_05
+      description: Reject mapping device to sbi while keeping ReqID parameter as Invalid in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "7472828",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_002"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Missing_Version_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_06
+      description: Reject mapping device to sbi while keeping Version parameter as Missing in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "$REMOVE$",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_003"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Null_Version_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_07
+      description: Reject mapping device to sbi while keeping Version parameter as Null in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "null",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_003"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Empty_Version_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_08
+      description: Reject mapping device to sbi while keeping Version parameter as Empty in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": " ",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_003"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Invalid_VersionValue1_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_09
+      description: Reject mapping device to sbi while keeping Version parameter as invalid value 1 in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_003"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Invalid_VersionValue0_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_10
+      description: Reject mapping device to sbi while keeping Version parameter as invalid value 0 in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_003"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Invalid_VersionValues_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_11
+      description: Reject mapping device to sbi while keeping Version parameter as invalid values in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "7288283",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_003"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_without_RequestTime_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_12
+      description: Reject mapping device to sbi without RequestTime parameter in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$REMOVE$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_004"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Empty_RequestTime_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_13
+      description: Reject mapping device to sbi while keeping RequestTime parameter as Empty in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_004"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Empty_RequestTimeString_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_14
+      description: Reject mapping device to sbi while keeping RequestTime parameter as Empty string in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": " ",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_004"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_different_format_RequestTime_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_15
+      description: Reject mapping device to sbi while keeping RequestTime value other than given format in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "1111-07-22T08:21:17.665Z",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_REQUEST_ERROR_006"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_invalid_object_paramter_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_16
+      description: Reject mapping device to sbi with invalid object paramter in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "jadhav",
+      "sbiId": "9329",
+      "deviceDetailId": "93130"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_005"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_invalid_Partner_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_17
+      description: Reject mapping device to sbi while keeping invalid Partner ID in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "100223111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_002"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_null_Partner_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_18
+      description: Reject mapping device to sbi while keeping null Partner ID in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "null",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_002"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Empty_Partner_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_19
+      description: Reject mapping device to sbi while keeping Empty Partner ID in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_002"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Invalid_SBI_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_20
+      description: Reject mapping device to sbi while keeping Invalid SBI ID in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "7281818",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_005"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_without_SBI_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_21
+      description: Reject mapping device to sbi while keeping without SBI ID in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_005"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_null_SBI_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_22
+      description: Reject mapping device to sbi while keeping null SBI ID in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "null",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_005"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Empty_SBI_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_23
+      description: Reject mapping device to sbi while keeping Empty SBI ID in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_005"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_random_SBI_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_24
+      description: Reject mapping device to sbi while keeping random SBI ID in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "731811993",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_005"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_already_Rejected_mapped_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_25
+      description: Reject mapping device to sbi while providing already rejeceted device ID in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_010"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_invalid_Device_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_26
+      description: Reject mapping device to sbi while providing invalid device ID in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "812293"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_006"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_with_different_Device_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_27
+      description: Reject mapping device to sbi with different device ID in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "233313"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_006"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_null_Device_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_28
+      description: Reject mapping device to sbi while keeping device ID as null in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "null"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_006"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_Empty_Device_ID_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_29
+      description: Reject mapping device to sbi while keeping device ID as Empty in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": " "
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_006"
+       }
+       ]
+}'
+   Pms_RejectMappingDeviceToSbi_invalid_Device_IDvalues_Neg:
+      endPoint: /v1/partnermanager/devicedetail/{deviceDetailId}/approval
+      uniqueIdentifier: TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_30
+      description: Reject mapping device to sbi while keeping device ID values in request and expecting an error in response
+      role: partneradmin
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios
+      outputTemplate: pms/error
+      input: '{
+      "id": "mosip.pms.approval.mapping.device.to.sbi.post",
+	  "version": "1.0",	
+      "requestTime": "$TIMESTAMP$",
+      "partnerId": "pms-111998",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid_id$",
+      "deviceDetailId": "8228828"
+}'
+      output: '{
+	  "errors": [
+      {
+       "errorCode": "PMS_DEVICE_ERROR_006"
+       }
+       ]
+}'

--- a/api-test/testNgXmlFiles/pmsSuite.xml
+++ b/api-test/testNgXmlFiles/pmsSuite.xml
@@ -486,6 +486,15 @@
 				name="io.mosip.testrig.apirig.testscripts.PostWithBodyAndPathParams" />
 		</classes>
 	</test>
+	<test name="ApproveMappingDeviceToSbiNegativeScenarios">
+		<parameter name="ymlFile"
+			value="pms/ApproveMappingDeviceToSbi/ApproveMappingDeviceToSbiNegativeScenarios.yml" />
+			<parameter name="pathParams" value="deviceDetailId" />
+		<classes>
+			<class
+				name="io.mosip.testrig.apirig.testscripts.PostWithBodyAndPathParams" />
+		</classes>
+	</test>	
 	<test name="RejectMappingDeviceToSbi">
 		<parameter name="ymlFile"
 			value="pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbi.yml" />
@@ -495,6 +504,15 @@
 				name="io.mosip.testrig.apirig.testscripts.PostWithBodyAndPathParams" />
 		</classes>
 	</test>
+	<test name="RejectMappingDeviceToSbiNegativeScenarios">
+		<parameter name="ymlFile"
+			value="pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios.yml" />
+			<parameter name="pathParams" value="deviceDetailId" />
+		<classes>
+			<class
+				name="io.mosip.testrig.apirig.testscripts.PostWithBodyAndPathParams" />
+		</classes>
+	</test>	
 	<test name="GetAllDeviceListMappedWithSbi">
 		<parameter name="ymlFile"
 			value="pms/GetAllDeviceListMappedWithSbi/GetAllDeviceListMappedWithSbi.yml" />


### PR DESCRIPTION
Automated below negative test cases for PMP Revamp,

1. Approve mapping device to SBI
2.  Reject mapping device to SBI
3. GetAllApprovedDeviceProviderIds->one scenario automated
4. DeactivateSBIWithAssociatedDevices -> Corrected a few test cases that were not running.