### PR TITLE
MOSIP-40119 - updated the error code for get partner certificate with unregistered partner id

### DIFF
--- a/api-test/src/main/resources/pms/GetCertificate/GetCert.yml
+++ b/api-test/src/main/resources/pms/GetCertificate/GetCert.yml
@@ -26,7 +26,7 @@ GetPartnerCert:
       output: '{
       "errors": [
       {
-       "errorCode": "PMS_CERTIFICATE_ERROR_007"
+       "errorCode": "PMS_PRT_005"
        }
        ]
 }'


### PR DESCRIPTION
MOSIP-40119 - updated the error code for get partner certificate with unregistered partner id