### PR TITLE
Fixed Automation API failures in the PMS API by addressing path parameter validation issues introduced as part of the Snyk security update.

### DIFF
--- a/api-test/README.md
+++ b/api-test/README.md
@@ -96,7 +96,7 @@ To execute the tests using Jar, use the following steps:
 
 2. Run the automation test suite JAR file:
    ```
-   java -jar -Dmodules=partner -Denv.user=api-internal.<env_name> -Denv.endpoint=<base_env> -Denv.testLevel=smokeAndRegression -jar apitest-partner-1.3.0-SNAPSHOT-jar-with-dependencies.jar
+   java -jar -Dmodules=partner -Denv.user=api-internal.<env_name> -Denv.endpoint=<base_env> -Denv.testLevel=smokeAndRegression -jar apitest-partner-1.3.0-jar-with-dependencies.jar
    ```
 
 # Using Eclipse IDE
@@ -152,7 +152,7 @@ To execute the tests using Eclipse IDE, use the following steps:
 - **env.user**: Replace `<env_name>` with the appropriate environment name (e.g., `dev`, `qa`, etc.).
 - **env.endpoint**: The environment where the application under test is deployed. Replace `<base_env>` with the correct base URL for the environment (e.g., `https://api-internal.<env_name>.mosip.net`).
 - **env.testLevel**: Set this to `smoke` to run only smoke test cases, or `smokeAndRegression` to run both smoke and regression tests.
-- **jar**: Specify the name of the JAR file to execute. The version will change according to the development code version. For example, the current version may look like `apitest-partner-1.3.0-SNAPSHOT-jar-with-dependencies.jar`.
+- **jar**: Specify the name of the JAR file to execute. The version will change according to the development code version. For example, the current version may look like `apitest-partner-1.3.0-jar-with-dependencies.jar`.
 
 ### Build and Run Info
 

--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -32,7 +32,19 @@
 			<organizationUrl>https://github.com/mosip/partner-management-services</organizationUrl>
 		</developer>
 	</developers>
-
+	
+	<repositories>
+		<repository>
+			<id>ossrh-central</id>
+			<name>MavenCentralRepository</name>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+			<layout>default</layout>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+	
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.3.2</version>
+			<version>1.3.3</version>
 		</dependency>
 	</dependencies>
 

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/AuditValidator.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/AuditValidator.java
@@ -32,6 +32,7 @@ import io.mosip.testrig.apirig.utils.AdminTestException;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class AuditValidator extends PMSUtil implements ITest {
@@ -69,7 +70,7 @@ public class AuditValidator extends PMSUtil implements ITest {
 	}
 
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DBValidator.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DBValidator.java
@@ -33,6 +33,7 @@ import io.mosip.testrig.apirig.utils.AdminTestException;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class DBValidator extends PMSUtil implements ITest {
@@ -70,7 +71,7 @@ public class DBValidator extends PMSUtil implements ITest {
 	}
 
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DownloadRootCertificate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DownloadRootCertificate.java
@@ -32,6 +32,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class DownloadRootCertificate extends PMSUtil implements ITest {
@@ -78,7 +79,7 @@ public class DownloadRootCertificate extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithParam.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class GetWithParam extends PMSUtil implements ITest {
@@ -77,7 +78,7 @@ public class GetWithParam extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithParamForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithParamForAutoGenId.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class GetWithParamForAutoGenId extends PMSUtil implements ITest {
@@ -79,7 +80,7 @@ public class GetWithParamForAutoGenId extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithQueryParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithQueryParam.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class GetWithQueryParam extends PMSUtil implements ITest {
@@ -76,7 +77,7 @@ public class GetWithQueryParam extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParam.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.ConfigManager;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PatchWithPathParam extends PMSUtil implements ITest {
@@ -76,7 +77,7 @@ public class PatchWithPathParam extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParamsAndBody.java
@@ -30,6 +30,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PatchWithPathParamsAndBody extends PMSUtil implements ITest {
@@ -77,7 +78,7 @@ public class PatchWithPathParamsAndBody extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithBodyAndPathParams.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithBodyAndPathParams.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PostWithBodyAndPathParams extends PMSUtil implements ITest {
@@ -80,7 +81,7 @@ public class PostWithBodyAndPathParams extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		String[] templateFields = testCaseDTO.getTemplateFields();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithBodyAndPathParamsAndAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithBodyAndPathParamsAndAutoGenId.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PostWithBodyAndPathParamsAndAutoGenId extends PMSUtil implements ITest {
@@ -82,7 +83,7 @@ public class PostWithBodyAndPathParamsAndAutoGenId extends PMSUtil implements IT
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		String[] templateFields = testCaseDTO.getTemplateFields();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithOnlyPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithOnlyPathParam.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PostWithOnlyPathParam extends PMSUtil implements ITest {
@@ -76,7 +77,7 @@ public class PostWithOnlyPathParam extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		String[] templateFields = testCaseDTO.getTemplateFields();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PutWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PutWithPathParamsAndBody.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PutWithPathParamsAndBody extends PMSUtil implements ITest {
@@ -78,7 +79,7 @@ public class PutWithPathParamsAndBody extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		String[] templateFields = testCaseDTO.getTemplateFields();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePatch.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePatch.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.ConfigManager;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class SimplePatch extends PMSUtil implements ITest {
@@ -76,7 +77,7 @@ public class SimplePatch extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		String[] templateFields = testCaseDTO.getTemplateFields();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePatchForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePatchForAutoGenId.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class SimplePatchForAutoGenId extends PMSUtil implements ITest {
@@ -78,7 +79,7 @@ public class SimplePatchForAutoGenId extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		String[] templateFields = testCaseDTO.getTemplateFields();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePost.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePost.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class SimplePost extends PMSUtil implements ITest {
@@ -77,7 +78,7 @@ public class SimplePost extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		auditLogCheck = testCaseDTO.isAuditLogCheck();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePostForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePostForAutoGenId.java
@@ -32,6 +32,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class SimplePostForAutoGenId extends PMSUtil implements ITest {
@@ -82,7 +83,7 @@ public class SimplePostForAutoGenId extends PMSUtil implements ITest {
 	 */
 	@Test(dataProvider = "testcaselist")
 	public void test(TestCaseDTO testCaseDTO)
-			throws AuthenticationTestException, AdminTestException, NoSuchAlgorithmException {
+			throws AuthenticationTestException, AdminTestException, NoSuchAlgorithmException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePostWithoutBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePostWithoutBody.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class SimplePostWithoutBody extends PMSUtil implements ITest {
@@ -77,7 +78,7 @@ public class SimplePostWithoutBody extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		auditLogCheck = testCaseDTO.isAuditLogCheck();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePut.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePut.java
@@ -32,6 +32,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class SimplePut extends PMSUtil implements ITest {
@@ -77,7 +78,7 @@ public class SimplePut extends PMSUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = PMSUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/resources/config/pms.properties
+++ b/api-test/src/main/resources/config/pms.properties
@@ -3,3 +3,250 @@
 pms_db_schema=pms
 km_db_schema=keymgr
 audit_db_schema=audit
+
+#---------------------------------- End point(s) relative URLs ----------------------------------#
+authclientidsecretkeyURL = /v1/authmanager/authenticate/clientidsecretkey
+authentication = /v1/authmanager/authenticate/useridPwd
+authenticationInternal = /v1/authmanager/authenticate/internal/useridPwd
+preregSendOtp = /preregistration/v1/login/sendOtp/langcode
+preregValidateOtp = /preregistration/v1/login/validateOtp
+zoneMappingUrl = /v1/masterdata/zoneuser
+zoneNameUrl = /v1/masterdata/zones/zonename
+zoneMappingActivateUrl = /v1/masterdata/zoneuser
+userCenterMappingUrl = /v1/masterdata/usercentermapping
+bulkUploadUrl = /v1/admin/bulkupload
+currentUserURI=/#/uinservices/viewhistory
+actuatorEndpoint=/resident/v1/actuator/env
+actuatorAdminEndpoint=/v1/admin/actuator/env
+actuatorMasterDataEndpoint=/v1/masterdata/actuator/env
+actuatorIDAEndpoint=/idauthentication/v1/actuator/env
+actuatorRegprocEndpoint=/registrationprocessor/v1/registrationtransaction/actuator/env
+actuatorEsignetEndpoint=/v1/esignet/actuator/env
+tokenEndpoint=/v1/esignet/oauth/token
+esignetWellKnownEndPoint=/v1/esignet/oidc/.well-known/openid-configuration
+signupSettingsEndPoint=/v1/signup/settings
+esignetActuatorPropertySection=esignet-default.properties
+eSignetbaseurl=
+signupBaseUrl=
+injiCertifyBaseURL=
+
+
+
+#----------------------------- minio proprties ------------------------------#
+s3-user-key = minioadmin
+s3-user-secret = 
+s3-host = http://minio.minio:9000
+s3-account = automation
+s3-region = null
+reportExpirationInDays = 3
+s3-account-for-persona-data = personaData
+push-reports-to-s3 = no
+mountPathForReport=/home/mosip/testrig/report
+
+
+
+#---------------------------------- APP IDs ----------------------------------#
+#-- When test rig ran in docker, these values dervied from the environment ---#
+mosip_pms_app_id = partner
+mosip_resident_app_id = resident
+mosip_idrepo_app_id = idrepo
+mosip_regclient_app_id = registrationclient
+mosip_hotlist_app_id = hotlist
+mosip_regprocclient_app_id = regproc
+AuthAppID = resident
+mosip_admin_app_id = admin
+mosip_crvs1_app_id = ida
+
+
+
+
+#-------------------- Keycloak User Creation proprties ----------------------#
+#-- When test rig ran in docker,few of below dervied from the environment ---#
+new_Resident_User = 111995
+new_Resident_Password = 
+new_Resident_Role = default-roles-mosip,PARTNER_ADMIN
+roles.111995 = PARTNER_ADMIN,default-roles-mosip
+keycloak_UserName = admin
+keycloak-realm-id = mosip
+iam-users-to-create=111997,111998,220005,111992,globaladmin,111999,111887,111888,111777
+iam-users-password=mosip123,mosip123,mosip123,mosip123,mosip123,mosip123,mosip123,mosip123,mosip123
+roles.220005=GLOBAL_ADMIN,ID_AUTHENTICATION,REGISTRATION_ADMIN,REGISTRATION_SUPERVISOR,ZONAL_ADMIN
+roles.111997=AUTH_PARTNER,PARTNER_ADMIN,PMS_ADMIN,POLICYMANAGER,REGISTRATION_SUPERVISOR
+roles.111999=AUTH_PARTNER
+roles.111777=PARTNER_ADMIN,POLICYMANAGER
+roles.111887=AUTH_PARTNER,PARTNER_ADMIN,PMS_ADMIN,REGISTRATION_SUPERVISOR
+roles.111998=POLICYMANAGER
+roles.111992=GLOBAL_ADMIN
+roles.111998=DEVICE_PROVIDER
+roles.111888= FTM_PROVIDER
+roles.globaladmin = GLOBAL_ADMIN,REGISTRATION_ADMIN,uma_authorization,ZONAL_ADMIN,default-roles-mosip
+
+
+#------------------------- DB Connectivity proprties ------------------------#
+#-- When test rig ran in docker,few of below dervied from the environment ---#
+driver_class=org.postgresql.Driver
+pool_size=1
+dialect=org.hibernate.dialect.PostgreSQLDialect
+show_sql=true
+current_session_context_class=thread
+audit_username=postgres
+audit_default_schema=audit
+DB_PORT=
+installation-domain=
+partner_username=postgres
+partner_default_schema=partner
+reportLogPath=automationLogAndReport
+postgresqlUser=postgresql
+db-port=5432
+hibernate.connection.driver_class=org.postgresql.Driver
+hibernate.connection.pool_size=1
+hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+hibernate.show_sql=true
+hibernate.current_session_context_class=thread
+db-su-user=postgres
+master_db_schema=master
+ida_db_schema=ida
+pms_db_schema=pms
+
+
+#------------------------ Generic properties  ------------------------#
+preconfiguredOtp=111111
+# supported values yes or no. Assume that by Default e-signet is deployed
+eSignetDeployed=yes
+partnerUrlSuffix=
+reportIgnoredTestCases=yes
+reportKnownIssueTestCases=yes
+servicesNotDeployed=
+esignetMockBaseURL=esignet-insurance.
+sunBirdBaseURL=registry
+slack-webhook-url=
+serverErrorsToMonitor=
+pmsAuthInternal=true
+partner_password=mosip123
+partner_userName=111997
+partner_auth_userName=pms-111999
+partner_device_userName=pms-111998
+partner_ftm_userName=pms-111888
+partner_admin_userName=pms-111777
+partner_user_password=mosip123
+policytest_password=mosip123
+policytest_userName=111998
+policytest_without_pmrole_userName=111887
+admin_password=mosip123
+admin_userName=220005
+admin_zone_password=mosip123
+admin_zone_userName=globaladmin
+expirationTime=120
+
+
+
+#------------------------- Need to check if these are used or not ------------------------#
+OTPTimeOut = 181
+attempt = 10
+ConfigParameters=mosip.kernel.rid.length,mosip.kernel.uin.length,mosip.kernel.sms.country.code,mosip.kernel.sms.number.length,mosip.kernel.otp.default-length,mosip.kernel.otp.expiry-time,mosip.kernel.otp.key-freeze-time,mosip.kernel.otp.validation-attempt-threshold,mosip.kernel.otp.min-key-length,mosip.kernel.otp.max-key-length,mosip.kernel.licensekey.length,mosip.supported-languages
+# supported values are 0 ,1, 2 based on number of env languages
+langselect=0
+
+
+
+#---------------------------------- Path to store the authentication certificates ----------------------------------------------------------#
+authCertsPath=/home/mosip/authcerts
+
+
+#---------------------------------- Client IDs -------------------------------#
+#-- When test rig ran in docker, these values dervied from the environment ---#
+mosip_pms_client_id = mosip-pms-client
+mosip_partner_client_id = mosip-partner-client
+mosip_resident_client_id = mosip-resident-client
+mosip_idrepo_client_id = mosip-idrepo-client
+mosip_reg_client_id = mosip-reg-client
+mosip_admin_client_id = mosip-admin-client
+mosip_hotlist_client_id = mosip-hotlist-client
+mosip_regproc_client_id = mosip-regproc-client
+mpartner_default_mobile_client_id = mpartner-default-mobile
+mosip_testrig_client_id = mosip-testrig-client
+AuthClientID = mosip-resident-client
+mosip_crvs1_client_id = mosip-crvs1-client
+
+
+
+
+#---------------------------------- Modifiable Properties ----------------------------------------------------------#
+
+#------------------------ Environment URLs and Database Connections ------------------------#
+
+# Keycloak URL.
+keycloak-external-url = https://iam.dev1.mosip.net
+
+# PostgreSQL URLs for audit and partner databases.
+audit_url = jdbc:postgresql://dev1.mosip.net:5432/mosip_audit
+partner_url = jdbc:postgresql://dev1.mosip.net:5432/mosip_ida
+
+# Database server for connections.
+db-server = api-internal.dev1.mosip.net
+
+
+#------------------------ secrets and passwords  ------------------------#
+
+#------------------------ Keycloak Passwords ------------------------#
+# Used for Keycloak authentication.
+keycloak_Password = OpdXlHylA1
+
+#------------------------ PostgreSQL Database Passwords ------------------------#
+# Credentials for connecting to Postgres databases.
+audit_password = HEdMa9ZXir7Tu2F
+partner_password = HEdMa9ZXir7Tu2F
+postgres-password = HEdMa9ZXir7Tu2F
+
+#-------- Client Secret Keys ----------#
+# These keys are used for various services, make sure to update the values as required when running locally.
+
+mosip_partner_client_secret = 
+mosip_pms_client_secret = 3Kdxn1h2Gv5aFbUK
+mosip_resident_client_secret = bbVNsZIj5YejJyil
+mosip_idrepo_client_secret = X1yYkkcuPru9IeMN
+mosip_reg_client_secret = BouQC901CH817zDg
+mosip_admin_client_secret = DagjTf1b6ffMQmrw
+mosip_hotlist_client_secret = WRr9RTGoZvBRmByS
+mosip_regproc_client_secret = e8iIPjBbmUQnUIeS
+mpartner_default_mobile_secret = s1iprLyR7BLuh0KN
+mosip_testrig_client_secret = BFwfePJnbicD4ytv
+AuthClientSecret = 
+mosip_crvs1_client_secret = 
+
+
+#-------- Generic Configuration ----------#
+
+# Enable or disable debugging mode (yes/no).
+enableDebug = yes
+
+# Whether to use pre-configured OTP (true/false).
+usePreConfiguredOtp = false
+
+# Mock Notification Channels (email/phone/email,phone).
+mockNotificationChannel = email,phone
+
+
+#------------------------ Mosip Components Base URLs ------------------------#
+# Define base URLs for different components if required.
+# Example: 
+# mosip_components_base_urls = auditmanager=api-internal.released.mosip.net;idrepository=api-internal.released.mosip.net;authmanager=api-internal.released.mosip.net;resident=api-internal.released.mosip.net;partnermanager=api-internal.released.mosip.net;idauthentication=api-internal.released.mosip.net;masterdata=api-internal.released.mosip.net;idgenerator=api-internal.released.mosip.net;policymanager=api-internal.released.mosip.net;preregistration=api-internal.released.mosip.net;keymanager=api-internal.released.mosip.net;mock-identity-system=api.released.mosip.net
+# Feel free to add more components as needed.
+mosip_components_base_urls =
+
+#------------------------ Module Name Pattern ------------------------#
+# Define module name pattern if required.
+# Example: 
+# moduleNamePattern = (mimoto|resident)
+# Feel free to add more values as needed.
+moduleNamePattern =
+
+
+#------------------------ Uncomment for Local Run ------------------------#
+
+# Path to the authentication certificates (if running locally, uncomment the below line and keep the value empty).
+authCertsPath =
+
+# X-XSS-Protection: Controls the XSS (Cross-Site Scripting) filter in browsers.
+# Values: (yes/no)
+xssProtectionCheck = no

--- a/api-test/src/main/resources/pms/DeactivateOIDCClient/DeactivateOIDCClient.yml
+++ b/api-test/src/main/resources/pms/DeactivateOIDCClient/DeactivateOIDCClient.yml
@@ -102,7 +102,7 @@ DeactivateOIDCClient:
       output: '{
     "errors": [
     {
-            "errorCode": "PMS_ESI_004"
+            "errorCode": "PMS_PRT_099"
         }
   ]
 }'

--- a/api-test/src/main/resources/pms/GetAllDeviceListMappedWithSbi/GetAllDeviceListMappedWithSbiNegativeScenarios.yml
+++ b/api-test/src/main/resources/pms/GetAllDeviceListMappedWithSbi/GetAllDeviceListMappedWithSbiNegativeScenarios.yml
@@ -47,7 +47,7 @@ GetAllDeviceListMappedWithSbiNegativeScenarios:
       inputTemplate: pms/GetAllDeviceListMappedWithSbi/GetAllDeviceListMappedWithSbi
       outputTemplate: pms/error
       input: '{
-       "sbiId": "$ID:GetListOfAllSBI_status_pending_approval_sid_sbiId$"
+       "sbiId": "$ID:GetListOfAllSBI_partnerId_valid_sid_sbiId$"
 }'
       output: '{
       "errors": [

--- a/api-test/src/main/resources/pms/GetAllNotifications/GetAllNotifications.yml
+++ b/api-test/src/main/resources/pms/GetAllNotifications/GetAllNotifications.yml
@@ -38,6 +38,7 @@ GetAllNotifications:
 }'
       output: ' {
 }'
+
    Pms_GetAllNotifications_Invalid_Certificate_ID_Neg:
       endPoint: /v1/partnermanager/notifications?pageNo=0&pageSize=8&certificateId=777apple123
       role: partneradmin

--- a/api-test/src/main/resources/pms/GetListOfAllSBI/GetListOfAllSBI.yml
+++ b/api-test/src/main/resources/pms/GetListOfAllSBI/GetListOfAllSBI.yml
@@ -173,8 +173,8 @@ GetListOfAllSBI:
 }'
       output: ' {
 }'
-   Pms_GetListOfAllSBI_partnerId_valid:
-      endPoint: /v1/partnermanager/securebiometricinterface
+   Pms_GetListOfAllSBI_partnerId_valid_sid:
+      endPoint: /v1/partnermanager/securebiometricinterface?partnerId={partnerId}
       uniqueIdentifier: TC_PMS_SBI_List_15      
       description: Fetching all the active SBI with partnerId contains 'a'
       role: partneradmin
@@ -192,7 +192,7 @@ GetListOfAllSBI:
       "pageNo": "$REMOVE$",
       "pageSize": "$REMOVE$",
       "sbiVersion": "$REMOVE$",
-      "policyId": "$REMOVE$      
+      "policyId": "$REMOVE$"
 }'
       output: ' {
 }'
@@ -244,8 +244,7 @@ GetListOfAllSBI:
 }'
       output: ' {
 }'
-
-   Pms_GetListOfAllSBI_random_value_given:
+   Pms_GetListOfAllSBI_random_value_given_sid:
       endPoint: /v1/partnermanager/securebiometricinterface
       uniqueIdentifier: TC_PMS_SBI_List_18      
       description: Fetching all the active SBI with random value for partnerId

--- a/api-test/src/main/resources/pms/GetListOfPartners/GetListOfPartners.yml
+++ b/api-test/src/main/resources/pms/GetListOfPartners/GetListOfPartners.yml
@@ -117,7 +117,7 @@ GetListOfPartners:
       ]
 }'
    Pms_GetListOfPartners_invalid_pageno_Neg:
-      endPoint: /v1/partnermanager/admin-partners?pageNo=22
+      endPoint: /v1/partnermanager/admin-partners?pageNo=-1
       description: Fetching all the active List Of Partner with invalid sort
       role: partneradmin
       uniqueIdentifier: TC_PMS_GetListOfPartners_08	  
@@ -128,7 +128,11 @@ GetListOfPartners:
       input: '{
 }'
       output: '{
-      "pageNo": "0"
+      "errors": [
+      {
+       "errorCode": "PMS_PRT_360"		
+      }
+      ]	  	
 }'
    Pms_GetListOfPartners_empty_pageno_Neg:
       endPoint: /v1/partnermanager/admin-partners?pageNo=111111
@@ -165,6 +169,7 @@ GetListOfPartners:
    Pms_GetListOfPartners_invalid_partnerid_Neg:
       endPoint: /v1/partnermanager/admin-partners?partnerId=-dndn333
       description: Fetching all the active List Of Partner with invalid sort
+      uniqueIdentifier: TC_PMS_GetListOfPartners_11
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -178,19 +183,7 @@ GetListOfPartners:
    Pms_GetListOfPartners_empty_partnerid_Neg:
       endPoint: /v1/partnermanager/admin-partners?partnerId=bcbcb
       description: Fetching all the active List Of Partner with invalid sort
-      role: partneradmin
-      checkErrorsOnlyInResponse: true
-      restMethod: get
-      inputTemplate: pms/GetListOfPartners/getListOfPartners
-      outputTemplate: pms/error
-      input: '{
-}'
-      output: '{
-      "pageNo": "0"
-}'
-   Pms_GetListOfPartners_empty_partnerid_Neg:
-      endPoint: /v1/partnermanager/admin-partners?partnerId=bcbcb
-      description: Fetching all the active List Of Partner with invalid sort
+      uniqueIdentifier: TC_PMS_GetListOfPartners_12
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -204,6 +197,7 @@ GetListOfPartners:
    Pms_GetListOfPartners_invalid_partnertype_Neg:
       endPoint: /v1/partnermanager/admin-partners?partnerType=2233ddd
       description: Fetching all the active List Of Partner with invalid sort
+      uniqueIdentifier: TC_PMS_GetListOfPartners_13
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -217,6 +211,7 @@ GetListOfPartners:
    Pms_GetListOfPartners_empty_partnertype_Neg:
       endPoint: /v1/partnermanager/admin-partners?partnerType=dfdgd
       description: Fetching all the active List Of Partner with invalid sort
+      uniqueIdentifier: TC_PMS_GetListOfPartners_14
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -230,6 +225,7 @@ GetListOfPartners:
    Pms_GetListOfPartners_with_deactivated_partner_Neg:
       endPoint: /v1/partnermanager/admin-partners?isActive=false
       description: Fetching all the active List Of Partner with invalid sort
+      uniqueIdentifier: TC_PMS_GetListOfPartners_15
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -243,6 +239,7 @@ GetListOfPartners:
    Pms_GetListOfPartners_with_invalid_organization_name_Neg:
       endPoint: /v1/partnermanager/admin-partners?orgName=123@1sse
       description: Fetching all the active List Of Partner with invalid sort
+      uniqueIdentifier: TC_PMS_GetListOfPartners_16
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -256,6 +253,7 @@ GetListOfPartners:
    Pms_GetListOfPartners_with_empty_organization_name_Neg:
       endPoint: /v1/partnermanager/admin-partners?orgName=123@1sse
       description: Fetching all the active List Of Partner with invalid sort
+      uniqueIdentifier: TC_PMS_GetListOfPartners_17
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -269,6 +267,7 @@ GetListOfPartners:
    Pms_GetListOfPartners_with_empty_emailAddress_Neg:
       endPoint: /v1/partnermanager/admin-partners?emailAddress=454646
       description: Fetching all the active List Of Partner with invalid sort
+      uniqueIdentifier: TC_PMS_GetListOfPartners_18
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -282,6 +281,7 @@ GetListOfPartners:
    Pms_GetListOfPartners_with_invalid_email_Neg:
       endPoint: /v1/partnermanager/admin-partners?emailAddress=2t63t@@@
       description: Fetching all the active List Of Partner with invalid sort
+      uniqueIdentifier: TC_PMS_GetListOfPartners_19
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -295,6 +295,7 @@ GetListOfPartners:
    Pms_GetListOfPartners_with_not_uploaded_email_Neg:
       endPoint: /v1/partnermanager/admin-partners?certificateUploadStatus=not_uploaded
       description: Fetching all the active List Of Partner with invalid sort
+      uniqueIdentifier: TC_PMS_GetListOfPartners_20
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -308,6 +309,7 @@ GetListOfPartners:
    Pms_GetListOfPartners_with_invalid_policyGroup_Name_Neg:
       endPoint: /v1/partnermanager/admin-partners?policyGroupName=-12
       description: Fetching all the active List Of Partner with invalid sort
+      uniqueIdentifier: TC_PMS_GetListOfPartners_21
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -321,6 +323,7 @@ GetListOfPartners:
    Pms_GetListOfPartners_with_empty_policyGroup_Name_Neg:
       endPoint: /v1/partnermanager/admin-partners?policyGroupName=
       description: Fetching all the active List Of Partner with invalid sort
+      uniqueIdentifier: TC_PMS_GetListOfPartners_22
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -331,9 +334,108 @@ GetListOfPartners:
       output: '{
       "pageNo": "0"
 }'
-   Pms_GetListOfPartners_with_invalid_policyGroup_Name_Neg:
-      endPoint: /v1/partnermanager/admin-partners?policyGroupName=@374b
-      description: Fetching all the active List Of Partner with invalid sort
+   Pms_GetListOfPartners_Filter_isActive_type_true:
+      endPoint: /v1/partnermanager/admin-partners?pageSize=8&isActive=true
+      description: Retrieving all the Active partners
+      uniqueIdentifier: TC_PMS_GetListOfPartners_23
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: get
+      inputTemplate: pms/GetListOfPartners/getListOfPartners
+      outputTemplate: pms/GetListOfPartners/GetListOfPartnersResult
+      input: '{
+}'
+      output: '{
+      "pageNo": "0"
+}'
+   Pms_GetListOfPartners_Filter_OrgName_SortType_asc:
+      endPoint: /v1/partnermanager/admin-partners?sortFieldName=orgName&sortType=ASC&pageNo=0&pageSize=8&orgName=partner
+      description: Retrieving all partners filtered by organization name and sorted in ascending order
+      uniqueIdentifier: TC_PMS_GetListOfPartners_24
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: get
+      inputTemplate: pms/GetListOfPartners/getListOfPartners
+      outputTemplate: pms/GetListOfPartners/GetListOfPartnersResult
+      input: '{
+}'
+      output: '{
+      "pageNo": "0"
+}'
+   Pms_GetListOfPartners_partnerType_Sort_asc:
+      endPoint: /v1/partnermanager/admin-partners?sortFieldName=partnerType&sortType=asc&pageSize=8&partnerType=Auth
+      description: Retrieving all partners filtered by partnerType and sorted in ascending order
+      uniqueIdentifier: TC_PMS_GetListOfPartners_25
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: get
+      inputTemplate: pms/GetListOfPartners/getListOfPartners
+      outputTemplate: pms/GetListOfPartners/GetListOfPartnersResult
+      input: '{
+}'
+      output: '{
+      "pageNo": "0"
+}'
+   Pms_GetListOfPartners_partnerType_Sort_desc:
+      endPoint: /v1/partnermanager/admin-partners?sortFieldName=partnerType&sortType=desc&pageSize=8&partnerType=Auth
+      description: Retrieving all partners filtered by partnerType and sorted in descending order
+      uniqueIdentifier: TC_PMS_GetListOfPartners_26
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: get
+      inputTemplate: pms/GetListOfPartners/getListOfPartners
+      outputTemplate: pms/GetListOfPartners/GetListOfPartnersResult
+      input: '{
+}'
+      output: '{
+      "pageNo": "0"
+}'
+   Pms_GetListOfPartners_partnerid_desc:
+      endPoint: /v1/partnermanager/admin-partners?sortFieldName=partnerId&sortType=desc&pageNo=0&pageSize=8
+      description: Retrieving all partners filtered by partnerid and sorted in descending order
+      uniqueIdentifier: TC_PMS_GetListOfPartners_27
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: get
+      inputTemplate: pms/GetListOfPartners/getListOfPartners
+      outputTemplate: pms/GetListOfPartners/GetListOfPartnersResult
+      input: '{
+}'
+      output: '{
+      "pageNo": "0"
+}'
+   Pms_GetListOfPartners_partnerid_asc:
+      endPoint: /v1/partnermanager/admin-partners?sortFieldName=partnerId&sortType=asc&pageNo=0&pageSize=8
+      description: Retrieving all partners filtered by partnerid and sorted in ascending order
+      uniqueIdentifier: TC_PMS_GetListOfPartners_28
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: get
+      inputTemplate: pms/GetListOfPartners/getListOfPartners
+      outputTemplate: pms/GetListOfPartners/GetListOfPartnersResult
+      input: '{
+}'
+      output: '{
+      "pageNo": "0"
+}'
+   Pms_GetListOfPartners_emailAddress_asc:
+      endPoint: /v1/partnermanager/admin-partners?sortFieldName=partnerId&sortType=asc&pageNo=0&pageSize=8
+      description: Retrieving all partners filtered by partnerid and sorted in ascending order
+      uniqueIdentifier: TC_PMS_GetListOfPartners_28
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: get
+      inputTemplate: pms/GetListOfPartners/getListOfPartners
+      outputTemplate: pms/GetListOfPartners/GetListOfPartnersResult
+      input: '{
+}'
+      output: '{
+      "pageNo": "0"
+}'
+   Pms_GetListOfPartners_invalid_sortFieldName_Neg:
+      endPoint: /v1/partnermanager/admin-partners?sortFieldName=-1&sortType=-1
+      description: Retrieving all partners filtered by sortFieldName with invalid data
+      uniqueIdentifier: TC_PMS_GetListOfPartners_29
       role: partneradmin
       checkErrorsOnlyInResponse: true
       restMethod: get
@@ -342,5 +444,87 @@ GetListOfPartners:
       input: '{
 }'
       output: '{
+      "errors": [
+      {
+       "errorCode": "PMS_PRT_357"		
+      }
+      ]	  	
+}'
+   Pms_GetListOfPartners_certificateUploadStatus:
+      endPoint: /v1/partnermanager/admin-partners?certificateUploadStatus=uploaded
+      description: Retrieving all partners filtered by certificateUploadStatus
+      uniqueIdentifier: TC_PMS_GetListOfPartners_30
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: get
+      inputTemplate: pms/GetListOfPartners/getListOfPartners
+      outputTemplate: pms/GetListOfPartners/GetListOfPartnersResult
+      input: '{
+}'
+      output: '{
       "pageNo": "0"
+}'
+   Pms_GetListOfPartners_certificateUploadStatus_asc:
+      endPoint: /v1/partnermanager/admin-partners?sortFieldName=certificateUploadStatus&sortType=asc&certificateUploadStatus=uploaded
+      description: Retrieving all partners filtered by certificateUploadStatus in ascending order
+      uniqueIdentifier: TC_PMS_GetListOfPartners_31
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: get
+      inputTemplate: pms/GetListOfPartners/getListOfPartners
+      outputTemplate: pms/GetListOfPartners/GetListOfPartnersResult
+      input: '{
+}'
+      output: '{
+      "pageNo": "0"
+}'
+   Pms_GetListOfPartners_certificateUploadStatus_desc:
+      endPoint: /v1/partnermanager/admin-partners?sortFieldName=certificateUploadStatus&sortType=desc&certificateUploadStatus=uploaded
+      description: Retrieving all partners filtered by certificateUploadStatus in descending order
+      uniqueIdentifier: TC_PMS_GetListOfPartners_32
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: get
+      inputTemplate: pms/GetListOfPartners/getListOfPartners
+      outputTemplate: pms/GetListOfPartners/GetListOfPartnersResult
+      input: '{
+}'
+      output: '{
+      "pageNo": "0"
+}'
+   Pms_GetListOfPartners_certificateUploadStatus_asc_without_sortFieldName_Neg:
+      endPoint: /v1/partnermanager/admin-partners?sortType=asc&certificateUploadStatus=uploaded
+      description: Retrieving all partners filtered by certificateUploadStatus in ascending order and without sortFieldName
+      uniqueIdentifier: TC_PMS_GetListOfPartners_33
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: get
+      inputTemplate: pms/GetListOfPartners/getListOfPartners
+      outputTemplate: pms/error
+      input: '{
+}'
+      output: '{
+      "errors": [
+      {
+       "errorCode": "PMS_PS_ERROR_007"		
+      }
+      ]	  	
+}'
+   Pms_GetListOfPartners_invalid_sortType_Neg:
+      endPoint: /v1/partnermanager/admin-partners?sortFieldName=partnerId&sortType=-1
+      description: Retrieving all partners filtered with invalid sortType
+      uniqueIdentifier: TC_PMS_GetListOfPartners_34
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: get
+      inputTemplate: pms/GetListOfPartners/getListOfPartners
+      outputTemplate: pms/error
+      input: '{
+}'
+      output: '{
+      "errors": [
+      {
+       "errorCode": "PMS_PRT_358"		
+      }
+      ]	  	
 }'

--- a/api-test/src/main/resources/pms/GetOriginalFtmCertifacte/GetOriginalFtmCertifacteNegativeScenarios.yml
+++ b/api-test/src/main/resources/pms/GetOriginalFtmCertifacte/GetOriginalFtmCertifacteNegativeScenarios.yml
@@ -53,7 +53,7 @@ GetOriginalFtmCertifacteNegativeScenarios:
       output: '{
       "errors": [
       {
-       "errorCode": "PMS_FTM_ERROR_005"
+       "errorCode": "PMS_PRT_099"
        }
        ]
 }'
@@ -91,7 +91,7 @@ GetOriginalFtmCertifacteNegativeScenarios:
       output: '{
       "errors": [
       {
-       "errorCode": "PMS_FTM_ERROR_005"
+       "errorCode": "PMS_PRT_099"
        }
        ]
 }'

--- a/api-test/src/main/resources/pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios.yml
+++ b/api-test/src/main/resources/pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios.yml
@@ -725,7 +725,7 @@ RejectMappingDeviceToSbiNegativeScenarios:
       "version": "1.0",	
       "requestTime": "$TIMESTAMP$",
       "partnerId": "pms-111998",
-      "sbiId": "$ID:GetListOfAllSBI_status_pending_approval_sid_sbiId$",
+      "sbiId": "$ID:GetListOfAllSBI_partnerId_valid_sid_sbiId$",
       "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
 }'
       output: '{

--- a/api-test/testNgXmlFiles/pmsSuite.xml
+++ b/api-test/testNgXmlFiles/pmsSuite.xml
@@ -692,14 +692,14 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
 	</test>
-
+<!--	POST /partners/search has been deprecated from release 1.2.2.0 onwards, replaced by GET /admin-partners with updated test cases.
 	<test name="SearchPartner">
 		<parameter name="ymlFile"
 			value="pms/SearchAPIs/SearchPartner/createSearchPartner.yml" />
 		<classes>
 			<class name="io.mosip.testrig.apirig.partner.testscripts.SimplePost" />
 		</classes>
-	</test>
+	</test>-->
 	<test name="CreateDeviceDetail">
 		<parameter name="ymlFile"
 			value="pms/device/makeAndModel/create/CreateDeviceDetail.yml" />
@@ -859,7 +859,7 @@
 		<parameter name="ymlFile"
 			value="pms/GetListOfAllSBI/GetListOfAllSBI.yml" />
 		<parameter name="pathParams"
-			value="sortFieldName,sortType,status,sbiVersion" />
+			value="partnerId,sortFieldName,sortType,status,sbiVersion" />
 		<parameter name="idKeyName" value="sbiId" />
 		<classes>
 			<class
@@ -1366,6 +1366,8 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
 	</test>
+<!--	GET /partners has been deprecated from release 1.2.2.0 onwards, replaced by GET /admin-partners with updated test cases.
+	added in GET /admin-partners 
 	<test name="GetPartners">
 		<parameter name="ymlFile"
 			value="pms/GetPartners/GetPartners.yml" />
@@ -1373,7 +1375,7 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
-	</test>
+	</test>-->
 	<test name="ActivateDeactivatePartner">
 		<parameter name="ymlFile"
 			value="pms/ActivateDeactivatePartner/ActivateDeactivatePartner.yml" />
@@ -1627,6 +1629,6 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
-	</test>		
+	</test>
 
 </suite>


### PR DESCRIPTION
 Resolved PMS API automation test failures for the following test cases:
1. DeactivateOIDCClient -> TC_PMS_DeactivateOIDCClient_04
2. GetOriginalFtmCertifacteNegativeScenarios -> TC_PMS_GetOriginalFtmCertifacteNegativeScenarios_04
3. GetOriginalFtmCertifacteNegativeScenarios -> TC_PMS_GetOriginalFtmCertifacteNegativeScenarios_06