### PR TITLE
Mosip 1.2.2.x: Fixed SBI dependency by using valid orgName-based SBI list in dependent PMS testcases.

### DIFF
--- a/api-test/src/main/resources/pms/GetAllDeviceListMappedWithSbi/GetAllDeviceListMappedWithSbiNegativeScenarios.yml
+++ b/api-test/src/main/resources/pms/GetAllDeviceListMappedWithSbi/GetAllDeviceListMappedWithSbiNegativeScenarios.yml
@@ -47,7 +47,7 @@ GetAllDeviceListMappedWithSbiNegativeScenarios:
       inputTemplate: pms/GetAllDeviceListMappedWithSbi/GetAllDeviceListMappedWithSbi
       outputTemplate: pms/error
       input: '{
-       "sbiId": "$ID:GetListOfAllSBI_partnerId_valid_sid_sbiId$"
+       "sbiId": "$ID:GetListOfAllSBI_orgName_valid_sid_sbiId$"
 }'
       output: '{
       "errors": [

--- a/api-test/src/main/resources/pms/GetListOfAllSBI/GetListOfAllSBI.yml
+++ b/api-test/src/main/resources/pms/GetListOfAllSBI/GetListOfAllSBI.yml
@@ -150,7 +150,7 @@ GetListOfAllSBI:
 }'
       output: ' {
 }'
-   Pms_GetListOfAllSBI_orgName_valid:
+   Pms_GetListOfAllSBI_orgName_valid_sid:
       endPoint: /v1/partnermanager/securebiometricinterface
       uniqueIdentifier: TC_PMS_SBI_List_14      
       description: Fetching all the active SBI with orgName contains '1'
@@ -196,7 +196,6 @@ GetListOfAllSBI:
 }'
       output: ' {
 }'
-
    Pms_GetListOfAllSBI_sortType_ASC:
       endPoint: /v1/partnermanager/securebiometricinterface?sortType={sortType}&sortFieldName={sortFieldName}&pageNo={pageNo}&pageSize={pageSize}
       uniqueIdentifier: TC_PMS_SBI_List_15      

--- a/api-test/src/main/resources/pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios.yml
+++ b/api-test/src/main/resources/pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios.yml
@@ -725,7 +725,7 @@ RejectMappingDeviceToSbiNegativeScenarios:
       "version": "1.0",	
       "requestTime": "$TIMESTAMP$",
       "partnerId": "pms-111998",
-      "sbiId": "$ID:GetListOfAllSBI_partnerId_valid_sid_sbiId$",
+      "sbiId": "$ID:GetListOfAllSBI_orgName_valid_sid_sbiId$",
       "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
 }'
       output: '{


### PR DESCRIPTION
- Updated dependent testcases to use 'Pms_GetListOfAllSBI_orgName_valid_sid' instead of invalid partnerId-based SBI fetch.
- Ensured valid sbiId is returned to avoid SkipException in:
  1. RejectMappingDeviceToSbi_Provide_different_SBIID_Neg
  2. GetAllDeviceListMappedWithSbi_when_SBI_not_authenticated_device_provider_SBI_ID_Neg