### PR TITLE
MOSIP-43568: Fixed negative PMS API test failures and update commons version for smoke test execution in Proper Order.

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.3.1</version>
+			<version>1.3.2</version>
 		</dependency>
 	</dependencies>
 

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testrunner/MosipTestRunner.java
@@ -24,6 +24,7 @@ import com.nimbusds.jose.jwk.RSAKey;
 
 import io.mosip.testrig.apirig.dbaccess.DBManager;
 import io.mosip.testrig.apirig.partner.utils.PMSRevampConfigManger;
+import io.mosip.testrig.apirig.partner.utils.PMSRevampConstants;
 import io.mosip.testrig.apirig.partner.utils.PMSRevampUtil;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.ExtractResource;
@@ -79,13 +80,11 @@ public class MosipTestRunner {
 			GlobalMethods.setModuleNameAndReCompilePattern(PMSRevampConfigManger.getproperty("moduleNamePattern"));
 			setLogLevels();
 
-			// For now we are not doing health check for qa-115.
-			if (BaseTestCase.isTargetEnvLTS()) {
-				HealthChecker healthcheck = new HealthChecker();
-				healthcheck.setCurrentRunningModule(BaseTestCase.currentModule);
-				Thread trigger = new Thread(healthcheck);
-				trigger.start();
-			}
+			HealthChecker healthcheck = new HealthChecker();
+			healthcheck.setCurrentRunningModule(BaseTestCase.currentModule);
+			Thread trigger = new Thread(healthcheck);
+			trigger.start();
+			
 			KeycloakUserManager.removeUser();
 			KeycloakUserManager.createUsers();
 			KeycloakUserManager.closeKeycloakInstance();
@@ -96,8 +95,7 @@ public class MosipTestRunner {
 			LOGGER.error("Exception " + e.getMessage());
 		}
 
-		if (BaseTestCase.isTargetEnvLTS())
-			HealthChecker.bTerminate = true;
+		HealthChecker.bTerminate = true;
 
 		System.exit(0);
 
@@ -117,8 +115,7 @@ public class MosipTestRunner {
 	
 		PMSRevampUtil.DbCleanRevamp();
 
-		BaseTestCase.currentModule = GlobalConstants.PARTNERNEW;
-		AdminTestUtil.copyPmsNewTestResource();
+		AdminTestUtil.copyPmsTestResource();
 	}
 
 	private static void setLogLevels() {
@@ -155,7 +152,7 @@ public class MosipTestRunner {
 				TestNG runner = new TestNG();
 				List<String> suitefiles = new ArrayList<>();
 				if (file.getName().toLowerCase().contains("mastertestsuite")) {
-					BaseTestCase.setReportName(GlobalConstants.PARTNERNEW);
+					BaseTestCase.setReportName(PMSRevampConstants.PARTNERNEW);
 					suitefiles.add(file.getAbsolutePath());
 					runner.setTestSuites(suitefiles);
 					System.getProperties().setProperty("testng.outpur.dir", "testng-report");

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/AuditValidator.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/AuditValidator.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 import org.testng.internal.BaseTestMethod;
 import org.testng.internal.TestResult;
 
-import io.mosip.testrig.apirig.dbaccess.AuditDBManager;
+import io.mosip.testrig.apirig.dbaccess.DBManager;
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;
 import io.mosip.testrig.apirig.partner.utils.PMSRevampConfigManger;
@@ -84,7 +84,7 @@ public class AuditValidator extends AdminTestUtil implements ITest {
 		
 		
 		logger.info(query);
-		Map<String, Object> response = AuditDBManager.executeQueryAndGetRecord(testCaseDTO.getRole(), query);
+		Map<String, Object> response = DBManager.executeQueryAndGetRecord(testCaseDTO.getRole(), query);
 		
 		
 		Map<String, List<OutputValidationDto>> objMap = new HashMap<>();
@@ -116,7 +116,7 @@ public class AuditValidator extends AdminTestUtil implements ITest {
 		
 		String deleteQuery = "delete from audit.app_audit_log where cr_by = '"+props.getProperty("partner_userName")+"'";
 		logger.info(deleteQuery);
-		AuditDBManager.executeQueryAndDeleteRecord("audit", deleteQuery);
+		DBManager.executeQueryAndDeleteRecord("audit", deleteQuery);
 		try {
 			Field method = TestResult.class.getDeclaredField("m_method");
 			method.setAccessible(true);

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DBValidator.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DBValidator.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 import org.testng.internal.BaseTestMethod;
 import org.testng.internal.TestResult;
 
-import io.mosip.testrig.apirig.dbaccess.AuditDBManager;
+import io.mosip.testrig.apirig.dbaccess.DBManager;
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.dto.TestCaseDTO;
 import io.mosip.testrig.apirig.partner.utils.PMSRevampConfigManger;
@@ -99,7 +99,7 @@ public class DBValidator extends AdminTestUtil implements ITest {
 		
 		
 		logger.info(query);
-		Map<String, Object> response = AuditDBManager.executeQueryAndGetRecord(testCaseDTO.getRole(), query);
+		Map<String, Object> response = DBManager.executeQueryAndGetRecord(testCaseDTO.getRole(), query);
 		
 		
 		Map<String, List<OutputValidationDto>> objMap = new HashMap<>();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/utils/PMSRevampConstants.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/utils/PMSRevampConstants.java
@@ -5,6 +5,7 @@ import io.mosip.testrig.apirig.utils.GlobalConstants;
 public class PMSRevampConstants extends GlobalConstants {
 
 	public static final String FEATURE_NOT_SUPPORTED_PMSREVAMP = "feature not supported. in the current version of MOSIP Platform. Hence skipping the testcase";
+	public static final String PARTNERNEW = "pms";
 	
 	
 	

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/utils/PMSRevampUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/utils/PMSRevampUtil.java
@@ -32,7 +32,7 @@ public class PMSRevampUtil extends AdminTestUtil {
 }
 	
 	public static void DbCleanRevamp() {
-		BaseTestCase.currentModule = GlobalConstants.PARTNERNEW;
+		BaseTestCase.currentModule = PMSRevampConstants.PARTNERNEW;
 		DBManager.executeDBQueries(PMSRevampConfigManger.getPMSDbUrl(), PMSRevampConfigManger.getPMSDbUser(),
 				PMSRevampConfigManger.getPMSDbPass(), PMSRevampConfigManger.getPMSDbSchema(),
 				getGlobalResourcePath() + "/" + "config/partnerRevampDataDeleteQueries.txt");

--- a/api-test/src/main/resources/pms/GetAllDeviceListMappedWithSbi/GetAllDeviceListMappedWithSbiNegativeScenarios.yml
+++ b/api-test/src/main/resources/pms/GetAllDeviceListMappedWithSbi/GetAllDeviceListMappedWithSbiNegativeScenarios.yml
@@ -47,7 +47,7 @@ GetAllDeviceListMappedWithSbiNegativeScenarios:
       inputTemplate: pms/GetAllDeviceListMappedWithSbi/GetAllDeviceListMappedWithSbi
       outputTemplate: pms/error
       input: '{
-       "sbiId": "$ID:GetListOfAllSBI_orgName_valid_sid_sbiId$"
+       "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_With_FTMPartner_Smoke_sid_id$"
 }'
       output: '{
       "errors": [

--- a/api-test/src/main/resources/pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios.yml
+++ b/api-test/src/main/resources/pms/RejectMappingDeviceToSbi/RejectMappingDeviceToSbiNegativeScenarios.yml
@@ -725,7 +725,7 @@ RejectMappingDeviceToSbiNegativeScenarios:
       "version": "1.0",	
       "requestTime": "$TIMESTAMP$",
       "partnerId": "pms-111998",
-      "sbiId": "$ID:GetListOfAllSBI_orgName_valid_sid_sbiId$",
+      "sbiId": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_With_FTMPartner_Smoke_sid_id$",
       "deviceDetailId": "$ID:SaveDeviceDetails_DeviceProviderForReject_AllValid_Smoke_sid_id$"
 }'
       output: '{

--- a/api-test/src/main/resources/pms/SaveSecureBiometricInterfaceCreateDto/SaveSecureBiometricInterfaceCreateDto.yml
+++ b/api-test/src/main/resources/pms/SaveSecureBiometricInterfaceCreateDto/SaveSecureBiometricInterfaceCreateDto.yml
@@ -17,8 +17,7 @@ SaveSecureBiometricInterfaceCreateDto:
       output: '{
           
 }'
-
-   Pms_SaveSecureBiometricInterfaceCreateDto_DeviceProvider_AllValid_Smoke_sid:
+   Pms_SaveSecureBiometricInterfaceCreateDto_DeviceProvider_With_FTMPartner_Smoke_sid:
       endPoint: /v1/partnermanager/securebiometricinterface
       role: partnerdevice
       checkErrorsOnlyInResponse: true
@@ -26,11 +25,11 @@ SaveSecureBiometricInterfaceCreateDto:
       inputTemplate: pms/SaveSecureBiometricInterfaceCreateDto/SaveSecureBiometricInterfaceCreateDto
       outputTemplate: pms/SaveSecureBiometricInterfaceCreateDto/SaveSecureBiometricInterfaceCreateDtoResult
       input: '{
-      	"swBinaryHash": "devicehaadsassh",
-      	"swVersion": "deviceswasdasd",
+      	"swBinaryHash": "sbi_ftmpartner_hash",
+      	"swVersion": "sbi_ftmpartner_version",
       	"swCreateDateTime": "$TIMESTAMP$",
       	"swExpiryDateTime": "2033-08-22T12:51:07.794Z",
-      	"providerId": "pms-111998"
+      	"providerId": "pms-111888"
 
 }'
       output: '{

--- a/api-test/src/main/resources/pms/UpdateSecureBiometricInterface/UpdateSecureBiometricInterface.yml
+++ b/api-test/src/main/resources/pms/UpdateSecureBiometricInterface/UpdateSecureBiometricInterface.yml
@@ -14,5 +14,18 @@ UpdateSecureBiometricInterface:
       output: '{
           "response": "Secure biometric details approved successfully."
 }'
+   Pms_UpdateSecureBiometricInterface_for_FTMPartner_Smoke:
+      endPoint: /v1/partnermanager/securebiometricinterface
+      role: partneradmin
+      checkErrorsOnlyInResponse: true
+      restMethod: patch
+      inputTemplate: pms/UpdateSecureBiometricInterface/UpdateSecureBiometricInterface
+      outputTemplate: pms/UpdateSecureBiometricInterface/UpdateSecureBiometricInterfaceResult
+      input: '{
+          "id": "$ID:SaveSecureBiometricInterfaceCreateDto_DeviceProvider_With_FTMPartner_Smoke_sid_id$",
+          "approvalStatus": "Activate"
 
-
+}'
+      output: '{
+          "response": "Secure biometric details approved successfully."
+}'


### PR DESCRIPTION
- Fixed failing negative test cases:

TC_PMS_RejectMappingDeviceToSbiNegativeScenarios_33
TC_PMS_GetAllDeviceListMappedWithSbiNegativeScenarios_03

- Updated commons version to ensure smoke tests execute in correct order

- Verified changes in RDT-1 environment