### PR TITLE
[MOSIP-43631] updated helm charts

### DIFF
--- a/helm/pms-partner/.gitignore
+++ b/helm/pms-partner/.gitignore
@@ -1,2 +1,2 @@
 charts/
-Charts.lock
+Chart.lock

--- a/helm/pms-partner/templates/deployment.yaml
+++ b/helm/pms-partner/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 60 }}      
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/helm/pms-partner/values.yaml
+++ b/helm/pms-partner/values.yaml
@@ -224,7 +224,7 @@ lifecycleHooks:
         - -c
         - sleep 30
 
-## Termination grace perios : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
+## Termination grace periods : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
 terminationGracePeriodSeconds: 60
 
 ## Custom Liveness probes for

--- a/helm/pms-partner/values.yaml
+++ b/helm/pms-partner/values.yaml
@@ -129,8 +129,8 @@ resources:
     cpu: 700m
     memory: 3500Mi
   requests:
-    cpu: 100m
-    memory: 1000Mi
+    cpu: 700m
+    memory: 3500Mi
 
 additionalResources:
   ## Specify any JAVA_OPTS string here. These typically will be specified in conjunction with above resources
@@ -216,7 +216,16 @@ podAnnotations: {}
 
 ## lifecycleHooks for the  container to automate configuration before or after startup.
 ##
-lifecycleHooks: {}
+lifecycleHooks:
+  preStop:
+    exec:
+      command:
+        - sh
+        - -c
+        - sleep 30
+
+## Termination grace perios : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
+terminationGracePeriodSeconds: 60
 
 ## Custom Liveness probes for
 ##
@@ -314,8 +323,8 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: "10"
+    repository: mosipid/os-shell
+    tag: "12-debian-12-r46"
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/helm/pms-partner/values.yaml
+++ b/helm/pms-partner/values.yaml
@@ -129,8 +129,8 @@ resources:
     cpu: 700m
     memory: 3500Mi
   requests:
-    cpu: 700m
-    memory: 3500Mi
+    cpu: 100m
+    memory: 1000Mi
 
 additionalResources:
   ## Specify any JAVA_OPTS string here. These typically will be specified in conjunction with above resources

--- a/helm/pms-policy/.gitignore
+++ b/helm/pms-policy/.gitignore
@@ -1,2 +1,2 @@
 charts/
-Charts.lock
+Chart.lock

--- a/helm/pms-policy/templates/deployment.yaml
+++ b/helm/pms-policy/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 60 }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/helm/pms-policy/values.yaml
+++ b/helm/pms-policy/values.yaml
@@ -129,8 +129,8 @@ resources:
     cpu: 500m
     memory: 3500Mi
   requests:
-    cpu: 500m
-    memory: 3500Mi
+    cpu: 100m
+    memory: 1000Mi
 
 additionalResources:
   ## Specify any JAVA_OPTS string here. These typically will be specified in conjunction with above resources

--- a/helm/pms-policy/values.yaml
+++ b/helm/pms-policy/values.yaml
@@ -127,10 +127,10 @@ resources:
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 500m
-    memory: 3000Mi
+    memory: 3500Mi
   requests:
-    cpu: 100m
-    memory: 1000Mi
+    cpu: 500m
+    memory: 3500Mi
 
 additionalResources:
   ## Specify any JAVA_OPTS string here. These typically will be specified in conjunction with above resources
@@ -216,7 +216,17 @@ podAnnotations: {}
 
 ## lifecycleHooks for the  container to automate configuration before or after startup.
 ##
-lifecycleHooks: {}
+lifecycleHooks:
+  preStop:
+    exec:
+      command:
+        - sh
+        - -c
+        - sleep 30
+
+## Termination grace perios : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
+terminationGracePeriodSeconds: 60
+
 
 ## Custom Liveness probes for
 ##
@@ -314,8 +324,8 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: "10"
+    repository: mosipid/os-shell
+    tag: "12-debian-12-r46"
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/helm/pms-policy/values.yaml
+++ b/helm/pms-policy/values.yaml
@@ -224,7 +224,7 @@ lifecycleHooks:
         - -c
         - sleep 30
 
-## Termination grace perios : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
+## Termination grace periods : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
 terminationGracePeriodSeconds: 60
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure Updates**
  * Increased CPU to 700m and memory limits to 3500Mi for affected services.
  * Added configurable termination grace period (default 60s) and preStop lifecycle hook that waits 30s for graceful shutdown.
  * Updated init/utility image reference to mosipid/os-shell:12-debian-12-r46 for volume permission handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->