### PR TITLE
MOSIP-44125 - Update apitest-commons version to 1.4.0-SNAPSHOT

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.3.6-SNAPSHOT</version>
+			<version>1.4.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
MOSIP-44125 - Update apitest-commons version to 1.4.0-SNAPSHOT