### PR TITLE
MOSIP-44222: Fix security issue caused by setAccessible(true) usage in PMS

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.4.0-SNAPSHOT</version>
+			<version>1.5.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/AuditValidator.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/AuditValidator.java
@@ -115,5 +115,7 @@ public class AuditValidator extends PMSUtil implements ITest {
 				+ PMSConfigManager.getproperty("partner_userName") + "'";
 		logger.info(deleteQuery);
 		DBManager.executeQueryAndDeleteRecord("audit", deleteQuery);
+
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/AuditValidator.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/AuditValidator.java
@@ -115,16 +115,5 @@ public class AuditValidator extends PMSUtil implements ITest {
 				+ PMSConfigManager.getproperty("partner_userName") + "'";
 		logger.info(deleteQuery);
 		DBManager.executeQueryAndDeleteRecord("audit", deleteQuery);
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DBIntegration.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DBIntegration.java
@@ -102,23 +102,4 @@ public class DBIntegration extends PMSUtil implements ITest {
 
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DBIntegration.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DBIntegration.java
@@ -102,4 +102,13 @@ public class DBIntegration extends PMSUtil implements ITest {
 
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DBValidator.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DBValidator.java
@@ -114,23 +114,4 @@ public class DBValidator extends PMSUtil implements ITest {
 			throw new AdminTestException("Failed at output validation");
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DBValidator.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DBValidator.java
@@ -114,4 +114,13 @@ public class DBValidator extends PMSUtil implements ITest {
 			throw new AdminTestException("Failed at output validation");
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DownloadRootCertificate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DownloadRootCertificate.java
@@ -140,4 +140,13 @@ public class DownloadRootCertificate extends PMSUtil implements ITest {
 		}
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DownloadRootCertificate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/DownloadRootCertificate.java
@@ -140,23 +140,4 @@ public class DownloadRootCertificate extends PMSUtil implements ITest {
 		}
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithParam.java
@@ -123,23 +123,4 @@ public class GetWithParam extends PMSUtil implements ITest {
 		}
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithParam.java
@@ -123,4 +123,13 @@ public class GetWithParam extends PMSUtil implements ITest {
 		}
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithParamForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithParamForAutoGenId.java
@@ -125,23 +125,4 @@ public class GetWithParamForAutoGenId extends PMSUtil implements ITest {
 			throw new AdminTestException("Failed at output validation");
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithParamForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithParamForAutoGenId.java
@@ -125,4 +125,13 @@ public class GetWithParamForAutoGenId extends PMSUtil implements ITest {
 			throw new AdminTestException("Failed at output validation");
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithQueryParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithQueryParam.java
@@ -128,23 +128,4 @@ public class GetWithQueryParam extends PMSUtil implements ITest {
 			throw new AdminTestException("Failed at output validation");
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithQueryParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/GetWithQueryParam.java
@@ -128,4 +128,13 @@ public class GetWithQueryParam extends PMSUtil implements ITest {
 			throw new AdminTestException("Failed at output validation");
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParam.java
@@ -122,4 +122,13 @@ public class PatchWithPathParam extends PMSUtil implements ITest {
 		}
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParam.java
@@ -122,23 +122,4 @@ public class PatchWithPathParam extends PMSUtil implements ITest {
 		}
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParamsAndBody.java
@@ -116,4 +116,13 @@ public class PatchWithPathParamsAndBody extends PMSUtil implements ITest {
 		return inputJson;
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParamsAndBody.java
@@ -116,23 +116,4 @@ public class PatchWithPathParamsAndBody extends PMSUtil implements ITest {
 		return inputJson;
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParamsAndBodyForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParamsAndBodyForAutoGenId.java
@@ -104,4 +104,13 @@ public class PatchWithPathParamsAndBodyForAutoGenId extends PMSUtil implements I
 
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParamsAndBodyForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PatchWithPathParamsAndBodyForAutoGenId.java
@@ -104,23 +104,4 @@ public class PatchWithPathParamsAndBodyForAutoGenId extends PMSUtil implements I
 
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithBodyAndPathParams.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithBodyAndPathParams.java
@@ -127,4 +127,13 @@ public class PostWithBodyAndPathParams extends PMSUtil implements ITest {
 			throw new AdminTestException("Failed at output validation");
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithBodyAndPathParams.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithBodyAndPathParams.java
@@ -127,23 +127,4 @@ public class PostWithBodyAndPathParams extends PMSUtil implements ITest {
 			throw new AdminTestException("Failed at output validation");
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithBodyAndPathParamsAndAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithBodyAndPathParamsAndAutoGenId.java
@@ -129,23 +129,4 @@ public class PostWithBodyAndPathParamsAndAutoGenId extends PMSUtil implements IT
 			throw new AdminTestException("Failed at output validation");
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithBodyAndPathParamsAndAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithBodyAndPathParamsAndAutoGenId.java
@@ -129,4 +129,13 @@ public class PostWithBodyAndPathParamsAndAutoGenId extends PMSUtil implements IT
 			throw new AdminTestException("Failed at output validation");
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithOnlyPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithOnlyPathParam.java
@@ -123,23 +123,4 @@ public class PostWithOnlyPathParam extends PMSUtil implements ITest {
 		}
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithOnlyPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PostWithOnlyPathParam.java
@@ -123,4 +123,13 @@ public class PostWithOnlyPathParam extends PMSUtil implements ITest {
 		}
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PutWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PutWithPathParamsAndBody.java
@@ -136,23 +136,4 @@ public class PutWithPathParamsAndBody extends PMSUtil implements ITest {
 				throw new AdminTestException("Failed at output validation");
 		}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PutWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PutWithPathParamsAndBody.java
@@ -136,4 +136,13 @@ public class PutWithPathParamsAndBody extends PMSUtil implements ITest {
 				throw new AdminTestException("Failed at output validation");
 		}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PutWithPathParamsAndBodyForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PutWithPathParamsAndBodyForAutoGenId.java
@@ -135,4 +135,13 @@ public class PutWithPathParamsAndBodyForAutoGenId extends PMSUtil implements ITe
 				throw new AdminTestException("Failed at output validation");
 		}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PutWithPathParamsAndBodyForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/PutWithPathParamsAndBodyForAutoGenId.java
@@ -135,23 +135,4 @@ public class PutWithPathParamsAndBodyForAutoGenId extends PMSUtil implements ITe
 				throw new AdminTestException("Failed at output validation");
 		}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePatch.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePatch.java
@@ -125,4 +125,13 @@ public class SimplePatch extends PMSUtil implements ITest {
 
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePatch.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePatch.java
@@ -125,23 +125,4 @@ public class SimplePatch extends PMSUtil implements ITest {
 
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePatchForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePatchForAutoGenId.java
@@ -125,4 +125,13 @@ public class SimplePatchForAutoGenId extends PMSUtil implements ITest {
 
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePatchForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePatchForAutoGenId.java
@@ -125,23 +125,4 @@ public class SimplePatchForAutoGenId extends PMSUtil implements ITest {
 
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePost.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePost.java
@@ -132,4 +132,13 @@ public class SimplePost extends PMSUtil implements ITest {
 
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePost.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePost.java
@@ -132,23 +132,4 @@ public class SimplePost extends PMSUtil implements ITest {
 
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePostForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePostForAutoGenId.java
@@ -137,4 +137,13 @@ public class SimplePostForAutoGenId extends PMSUtil implements ITest {
 			throw new AdminTestException("Failed at output validation");
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+	    result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePostForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePostForAutoGenId.java
@@ -137,23 +137,4 @@ public class SimplePostForAutoGenId extends PMSUtil implements ITest {
 			throw new AdminTestException("Failed at output validation");
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePostWithoutBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePostWithoutBody.java
@@ -133,23 +133,4 @@ public class SimplePostWithoutBody extends PMSUtil implements ITest {
 
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePostWithoutBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePostWithoutBody.java
@@ -133,4 +133,13 @@ public class SimplePostWithoutBody extends PMSUtil implements ITest {
 
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePut.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePut.java
@@ -125,23 +125,4 @@ public class SimplePut extends PMSUtil implements ITest {
 		}
 	}
 
-	/**
-	 * The method ser current test name to result
-	 * 
-	 * @param result
-	 */
-	@AfterMethod(alwaysRun = true)
-	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
-	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePut.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testscripts/SimplePut.java
@@ -125,4 +125,13 @@ public class SimplePut extends PMSUtil implements ITest {
 		}
 	}
 
+	/**
+	 * The method ser current test name to result
+	 * 
+	 * @param result
+	 */
+	@AfterMethod(alwaysRun = true)
+	public void setResultTestName(ITestResult result) {
+		result.setAttribute("TestCaseName", testCaseName);
+	}
 }


### PR DESCRIPTION
Removed reflection-based name mutation and recorded test case names via result attributes.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified test-suite result handling by removing reflection-based name mutation and recording test case names via result attributes.
  * Bumped internal test utilities package version to 1.5.0-SNAPSHOT.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->