### PR TITLE
[MOSIP-44443] Update GET /partners/v3 endpoint to support Manual Adjudication partner type

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/service/impl/PartnerServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/service/impl/PartnerServiceImpl.java
@@ -1896,7 +1896,7 @@ public class PartnerServiceImpl implements PartnerService {
 			boolean isPartnerAdmin = partnerHelper.isPartnerAdmin(authUserDetails().getAuthorities().toString());
 			List<Partner> partners = new ArrayList<>();
 			// if not MISP_Partner and ABIS_Partner type, fetch partners for logged in user
-			if (!PartnerConstants.MISP_PARTNER_TYPE.equals(partnerType) && !PartnerConstants.ABIS_PARTNER_TYPE.equals(partnerType)) {
+			if (!PartnerConstants.MISP_PARTNER_TYPE.equals(partnerType) && !PartnerConstants.ABIS_PARTNER_TYPE.equals(partnerType) && !PartnerConstants.MANUAL_ADJUDICATION_PARTNER_TYPE.equals(partnerType)) {
 				if (!isPartnerAdmin) {
 					List<Partner> partnerList = partnerRepository.findByUserId(userId);
 					if (partnerList.isEmpty()) {

--- a/partner/pms-common/src/main/java/io/mosip/pms/common/constant/PartnerConstants.java
+++ b/partner/pms-common/src/main/java/io/mosip/pms/common/constant/PartnerConstants.java
@@ -114,4 +114,6 @@ public final class PartnerConstants {
     
     public static final String GET_SIGNED_PARTNER_CERT_URL = "pmp.partner.original.certificate.get.rest.uri";
 
+	public static final String MANUAL_ADJUDICATION_PARTNER_TYPE ="Manual_Adjudication";
+
 }


### PR DESCRIPTION
[MOSIP-44350] 

[MOSIP-44350]: https://mosip.atlassian.net/browse/MOSIP-44350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Manual Adjudication partner type now follows admin-only access like other admin partner types; non-admin users will receive the admin/all dataset rather than user-specific data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->