### PR TITLE
MOSIP-44419: Fixed build failure in MosipTestRunner due to testCaseInterDependencyPath.

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testrunner/MosipTestRunner.java
@@ -119,7 +119,7 @@ public class MosipTestRunner {
 		// Used for generating the test case interdependency JSON file
 		if ("yes".equalsIgnoreCase(generateDependency)) {
 			LOGGER.info("Generating test case inter-dependencies");
-			AdminTestUtil.generateTestCaseInterDependencies(BaseTestCase.testCaseInterDependencyPath);
+			AdminTestUtil.generateTestCaseInterDependencies(BaseTestCase.getTestCaseInterDependencyPath());
 		} else {
 			LOGGER.info("Skipping dependency generation");
 		}


### PR DESCRIPTION
Added missing testCaseInterDependencyPath static variable in BaseTestCase to support test case inter-dependency generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal test infrastructure code organization through enhanced access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->