### PR TITLE
[MOSIP-44438] : Updated GET/partner-api-keys/v2 endpoint to include partnerType in request filter and response

### DIFF
--- a/docs/partner_management_service_api_documentation.json
+++ b/docs/partner_management_service_api_documentation.json
@@ -6982,7 +6982,7 @@
                     "partner-management-controller"
                 ],
                 "summary": "NEW: V2 version of get the list of all the API keys created by all the Auth Partners",
-                "description": "Added in PMS Release 1.3.x, this V2 version of endpoint `/partner-api-keys` which includes below new attributes added in the response:\r\n1. `apiKeyExpiryDateTime`\r\n2. `isApiKeyExpiredStatus`\r\nAlso this endpoint will also be used to populate the Count of expiring API keys in the corresponding Dashboard Card \r\nby passing the `expiryPeriod` optional request parameter.\r\n\r\nThis endpoint supports pagination, sorting, and filtering based on optional query parameters.\r\n\r\nIf the token used to access this endpoint, does not have the PARTNER_ADMIN role, then it will fetch all the API keys created by all the Auth Partners associated with the logged in user only.\r\n\r\nIf the token used to access this endpoint, has PARTNER_ADMIN role, then it will fetch all the API keys created by all the Auth Partners across all users.\r\n\r\nThis endpoint is designed to support the upcoming feature \"Multi Partner Type Support for a User\". With this feature one PMS user account will be able to support multiple Partner Types. Currently one PMS user account maps to one Partner Type and one Partner Id.\r\n\r\nThis endpoint should be configured for the Roles: PARTNER_ADMIN,AUTH_PARTNER\r\n",
+                "description": "Added in PMS Release 1.3.x, this V2 version of endpoint `/partner-api-keys` which includes below new attributes added in the response:\r\n1. `apiKeyExpiryDateTime`\r\n2. `isApiKeyExpiredStatus`\r\n3. `partnerType` (e.g. Auth_Partner, Manual_Adjudication)\r\nAlso this endpoint will also be used to populate the Count of expiring API keys in the corresponding Dashboard Card \r\nby passing the `expiryPeriod` optional request parameter.\r\n\r\nThis endpoint supports pagination, sorting, and filtering based on optional query parameters including `partnerType`. Filter by partnerType=Auth_Partner for Auth Services API keys list; filter by partnerType=Manual_Adjudication for Manual Adjudication Services API keys list. API keys for Manual Adjudication partners (e.g. on DataShare policy) are included when no partnerType filter is applied or when partnerType=Manual_Adjudication.\r\n\r\nIf the token used to access this endpoint, does not have the PARTNER_ADMIN role, then it will fetch all the API keys created by all the partners associated with the logged in user only.\r\n\r\nIf the token used to access this endpoint, has PARTNER_ADMIN role, then it will fetch all the API keys created by all the partners across all users.\r\n\r\nThis endpoint is designed to support the upcoming feature \"Multi Partner Type Support for a User\". With this feature one PMS user account will be able to support multiple Partner Types. Currently one PMS user account maps to one Partner Type and one Partner Id.\r\n\r\nThis endpoint should be configured for the Roles: PARTNER_ADMIN,AUTH_PARTNER\r\n",
                 "operationId": "get-auth-partners-apikeys-v2",
                 "parameters": [
                     {
@@ -7080,6 +7080,14 @@
                         }
                     },
                     {
+                        "name": "partnerType",
+                        "in": "query",
+                        "description": "Optional request parameter. Filter by partner type (e.g. Auth_Partner, Manual_Adjudication). Used by Auth Services and Manual Adjudication Services API keys list pages.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "schema": {
                             "type": "integer",
                             "minimum": 1,
@@ -7167,6 +7175,10 @@
                                                             "policyGroupDescription": {
                                                                 "type": "string",
                                                                 "description": "Description of the Policy Group"
+                                                            },
+                                                            "partnerType": {
+                                                                "type": "string",
+                                                                "description": "Type of partner (e.g. Auth_Partner, Manual_Adjudication)"
                                                             },
                                                             "status": {
                                                                 "type": "string",

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/constant/ErrorCode.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/constant/ErrorCode.java
@@ -221,7 +221,8 @@ public enum ErrorCode {
 	INACTIVE_PARTNER_CANNOT_BE_MAPPED("PMS_PRT_254", "Inactive partner cannot be mapped to policy group"),
 	POLICY_GROUP_LINK_NOT_ALLOWED("PMS_PRT_255", "Only MISP partners can be linked to a policy group. Partner type '%s' is not allowed."),
 	EMAIL_PARTNER_CONFLICT("PMS_PRT_268", "Email already registered with a different partnerId"),
-	PARTNER_VERIFICATION_ERROR("PMS_PRT_269", "Error while verifying partner"),;
+	PARTNER_VERIFICATION_ERROR("PMS_PRT_269", "Error while verifying partner"),
+	PARTNER_TYPE_FILTER_NOT_ALLOWED("PMS_PRT_270", "partnerType filter is allowed only for PARTNER_ADMIN users.");
 	/**
 	 * The error code.
 	 */

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/constant/ErrorCode.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/constant/ErrorCode.java
@@ -222,7 +222,8 @@ public enum ErrorCode {
 	POLICY_GROUP_LINK_NOT_ALLOWED("PMS_PRT_255", "Only MISP partners can be linked to a policy group. Partner type '%s' is not allowed."),
 	EMAIL_PARTNER_CONFLICT("PMS_PRT_268", "Email already registered with a different partnerId"),
 	PARTNER_VERIFICATION_ERROR("PMS_PRT_269", "Error while verifying partner"),
-	PARTNER_TYPE_FILTER_NOT_ALLOWED("PMS_PRT_270", "partnerType filter is allowed only for PARTNER_ADMIN users.");
+	PARTNER_TYPE_FILTER_NOT_ALLOWED("PMS_PRT_270", "partnerType filter is allowed only for PARTNER_ADMIN users."),
+	INVALID_PARTNER_TYPE_FOR_FILTER("PMS_PRT_271", "Invalid partnerType '%s'. Valid values are: Auth_Partner, Manual_Adjudication.");
 	/**
 	 * The error code.
 	 */

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
@@ -507,8 +507,8 @@ public class PartnerManagementController {
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getGetpartnersapikeyrequests())")
 	@GetMapping(value = "/partner-api-keys/v2")
-	@Operation(summary = "This endpoint retrieves a list of all the API keys created by the partners.",
-			description = "Available since release-1.3.0-beta.1. This endpoint supports pagination, sorting, and filtering based on optional query parameters including partnerType (e.g. Auth_Partner, Manual_Adjudication). If the token used to access this endpoint, does not have the PARTNER_ADMIN role, then it will fetch all the API keys created by all the partners associated with the logged in user only. If the token used to access this endpoint, has PARTNER_ADMIN role, then it will fetch all the API keys created by all the partners. Response includes partnerType for each API key.")
+	@Operation(summary = "This endpoint retrieves a list of all the API keys created by the Auth Partners.",
+			description = "Available since release-1.3.0-beta.1. This endpoint supports pagination, sorting, and and filtering based on optional query parameters. If the token used to access this endpoint, does not have the PARTNER_ADMIN role, then it will fetch all the API keys created by all the partners associated with the logged in user only. If the token used to access this endpoint, has PARTNER_ADMIN role, then it will fetch all the API keys created by all the partners.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "OK"),
 			@ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(hidden = true))),

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
@@ -502,8 +502,7 @@ public class PartnerManagementController {
 		inputValidator.validateRequestInput("status", status);
 		inputValidator.validateRequestInput("policyName", policyName);
 		inputValidator.validateRequestInput("policyGroupName", policyGroupName);
-		// Deprecated endpoint: always filter by Auth_Partner (legacy behaviour set at API boundary, not in service)
-		ApiKeyFilterDto filterDto = populateApiKeyFilterDto(partnerId, apiKeyLabel, orgName, status, policyName, policyGroupName, PartnerConstants.AUTH_PARTNER_TYPE, null);
+		ApiKeyFilterDto filterDto = populateApiKeyFilterDto(partnerId, apiKeyLabel, orgName, status, policyName, policyGroupName, null, null);
 		return partnerManagementService.getAllApiKeyRequests(sortFieldName, sortType, pageNo, pageSize, filterDto);
 	}
 

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
@@ -560,7 +560,7 @@ public class PartnerManagementController {
 		if (status != null) filterDto.setStatus(status);
 		if (policyName != null) filterDto.setPolicyName(policyName.toLowerCase());
 		if (policyGroupName != null) filterDto.setPolicyGroupName(policyGroupName.toLowerCase());
-		if (partnerType != null) filterDto.setPartnerType(partnerType.toLowerCase());
+		if (partnerType != null && !partnerType.isBlank()) filterDto.setPartnerType(partnerType.toLowerCase());
 		if (expiryPeriod != null) filterDto.setExpiryPeriod(expiryPeriod);
 		return filterDto;
 	}

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
@@ -3,6 +3,7 @@ package io.mosip.pms.partner.manager.controller;
 import java.util.List;
 import java.util.Optional;
 
+import io.mosip.pms.common.constant.PartnerConstants;
 import io.mosip.pms.common.dto.TrustCertificateSummaryDto;
 import io.mosip.pms.common.request.dto.RequestWrapperV2;
 import io.mosip.pms.common.util.RequestValidator;
@@ -501,7 +502,8 @@ public class PartnerManagementController {
 		inputValidator.validateRequestInput("status", status);
 		inputValidator.validateRequestInput("policyName", policyName);
 		inputValidator.validateRequestInput("policyGroupName", policyGroupName);
-		ApiKeyFilterDto filterDto = populateApiKeyFilterDto(partnerId, apiKeyLabel, orgName, status, policyName, policyGroupName, null, null);
+		// Deprecated endpoint: always filter by Auth_Partner (legacy behaviour set at API boundary, not in service)
+		ApiKeyFilterDto filterDto = populateApiKeyFilterDto(partnerId, apiKeyLabel, orgName, status, policyName, policyGroupName, PartnerConstants.AUTH_PARTNER_TYPE, null);
 		return partnerManagementService.getAllApiKeyRequests(sortFieldName, sortType, pageNo, pageSize, filterDto);
 	}
 

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
@@ -501,14 +501,14 @@ public class PartnerManagementController {
 		inputValidator.validateRequestInput("status", status);
 		inputValidator.validateRequestInput("policyName", policyName);
 		inputValidator.validateRequestInput("policyGroupName", policyGroupName);
-		ApiKeyFilterDto filterDto = populateApiKeyFilterDto(partnerId, apiKeyLabel, orgName, status, policyName, policyGroupName, null);
+		ApiKeyFilterDto filterDto = populateApiKeyFilterDto(partnerId, apiKeyLabel, orgName, status, policyName, policyGroupName, null, null);
 		return partnerManagementService.getAllApiKeyRequests(sortFieldName, sortType, pageNo, pageSize, filterDto);
 	}
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getGetpartnersapikeyrequests())")
 	@GetMapping(value = "/partner-api-keys/v2")
-	@Operation(summary = "This endpoint retrieves a list of all the API keys created by the Auth Partners.",
-			description = "Available since release-1.3.0-beta.1. This endpoint supports pagination, sorting, and and filtering based on optional query parameters. If the token used to access this endpoint, does not have the PARTNER_ADMIN role, then it will fetch all the API keys created by all the partners associated with the logged in user only. If the token used to access this endpoint, has PARTNER_ADMIN role, then it will fetch all the API keys created by all the partners.")
+	@Operation(summary = "This endpoint retrieves a list of all the API keys created by the partners.",
+			description = "Available since release-1.3.0-beta.1. This endpoint supports pagination, sorting, and filtering based on optional query parameters including partnerType (e.g. Auth_Partner, Manual_Adjudication). If the token used to access this endpoint, does not have the PARTNER_ADMIN role, then it will fetch all the API keys created by all the partners associated with the logged in user only. If the token used to access this endpoint, has PARTNER_ADMIN role, then it will fetch all the API keys created by all the partners. Response includes partnerType for each API key.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "OK"),
 			@ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(hidden = true))),
@@ -530,6 +530,8 @@ public class PartnerManagementController {
 			@RequestParam(value = "status", required = false) String status,
 			@RequestParam(value = "policyName", required = false) String policyName,
 			@RequestParam(value = "policyGroupName", required = false) String policyGroupName,
+			@Parameter(description = "Filter by partner type (e.g. Auth_Partner, Manual_Adjudication)", in = ParameterIn.QUERY)
+			@RequestParam(value = "partnerType", required = false) String partnerType,
 			@RequestParam(value = "expiryPeriod", required = false)
 			@Min(value = 1, message = "Expiry period must be at least 1 day.")
 			@Max(value = 30, message = "Expiry period cannot be more than 30 days.")
@@ -543,12 +545,13 @@ public class PartnerManagementController {
 		inputValidator.validateRequestInput("status", status);
 		inputValidator.validateRequestInput("policyName", policyName);
 		inputValidator.validateRequestInput("policyGroupName", policyGroupName);
-		ApiKeyFilterDto filterDto = populateApiKeyFilterDto(partnerId, apiKeyLabel, orgName, status, policyName, policyGroupName, expiryPeriod);
+		inputValidator.validateRequestInput("partnerType", partnerType);
+		ApiKeyFilterDto filterDto = populateApiKeyFilterDto(partnerId, apiKeyLabel, orgName, status, policyName, policyGroupName, partnerType, expiryPeriod);
 		return partnerManagementService.getAllApiKeyRequestsV2(sortFieldName, sortType, pageNo, pageSize, filterDto);
 	}
 
 	private ApiKeyFilterDto populateApiKeyFilterDto(String partnerId, String apiKeyLabel, String orgName, String status,
-													String policyName, String policyGroupName, Integer expiryPeriod) {
+													String policyName, String policyGroupName, String partnerType, Integer expiryPeriod) {
 		ApiKeyFilterDto filterDto = new ApiKeyFilterDto();
 		if (partnerId != null) filterDto.setPartnerId(partnerId.toLowerCase());
 		if (apiKeyLabel != null) filterDto.setApiKeyLabel(apiKeyLabel.toLowerCase());
@@ -556,6 +559,7 @@ public class PartnerManagementController {
 		if (status != null) filterDto.setStatus(status);
 		if (policyName != null) filterDto.setPolicyName(policyName.toLowerCase());
 		if (policyGroupName != null) filterDto.setPolicyGroupName(policyGroupName.toLowerCase());
+		if (partnerType != null) filterDto.setPartnerType(partnerType);
 		if (expiryPeriod != null) filterDto.setExpiryPeriod(expiryPeriod);
 		return filterDto;
 	}

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
@@ -560,7 +560,7 @@ public class PartnerManagementController {
 		if (status != null) filterDto.setStatus(status);
 		if (policyName != null) filterDto.setPolicyName(policyName.toLowerCase());
 		if (policyGroupName != null) filterDto.setPolicyGroupName(policyGroupName.toLowerCase());
-		if (partnerType != null) filterDto.setPartnerType(partnerType);
+		if (partnerType != null) filterDto.setPartnerType(partnerType.toLowerCase());
 		if (expiryPeriod != null) filterDto.setExpiryPeriod(expiryPeriod);
 		return filterDto;
 	}

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/dto/ApiKeyFilterDto.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/dto/ApiKeyFilterDto.java
@@ -9,6 +9,8 @@ public class ApiKeyFilterDto {
 
     private String partnerId;
 
+    private String partnerType;
+
     private String apiKeyLabel;
 
     private String orgName;

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/dto/ApiKeyRequestSummaryDto.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/dto/ApiKeyRequestSummaryDto.java
@@ -35,6 +35,9 @@ public class ApiKeyRequestSummaryDto {
     @Schema(description = "Description of the policy group the partner has selected", example = "PolicyGroup123")
     private String policyGroupDescription;
 
+    @Schema(description = "Type of partner (e.g., Auth_Partner, Manual_Adjudication)", example = "Auth_Partner")
+    private String partnerType;
+
     @Schema(description = "Status of the API key (e.g., activated, deactivated)", example = "activated")
     private String status;
 

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/dto/ApiKeyRequestSummaryDto.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/dto/ApiKeyRequestSummaryDto.java
@@ -35,9 +35,6 @@ public class ApiKeyRequestSummaryDto {
     @Schema(description = "Description of the policy group the partner has selected", example = "PolicyGroup123")
     private String policyGroupDescription;
 
-    @Schema(description = "Type of partner (e.g., Auth_Partner, Manual_Adjudication)", example = "Auth_Partner")
-    private String partnerType;
-
     @Schema(description = "Status of the API key (e.g., activated, deactivated)", example = "activated")
     private String status;
 

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/dto/ApiKeyRequestSummaryV2Dto.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/dto/ApiKeyRequestSummaryV2Dto.java
@@ -35,6 +35,9 @@ public class ApiKeyRequestSummaryV2Dto {
     @Schema(description = "Description of the policy group the partner has selected", example = "PolicyGroup123")
     private String policyGroupDescription;
 
+    @Schema(description = "Type of partner (e.g., Auth_Partner, Manual_Adjudication)", example = "Auth_Partner")
+    private String partnerType;
+
     @Schema(description = "Status of the API key (e.g., activated, deactivated)", example = "activated")
     private String status;
 

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -1385,6 +1385,10 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 						io.mosip.pms.partner.constant.ErrorCode.PARTNER_TYPE_FILTER_NOT_ALLOWED.getErrorCode(),
 						io.mosip.pms.partner.constant.ErrorCode.PARTNER_TYPE_FILTER_NOT_ALLOWED.getErrorMessage());
 			}
+
+			if (isPartnerAdmin && partnerType == null) {
+				partnerType = PartnerConstants.AUTH_PARTNER_TYPE.toLowerCase();
+			}
 			if (!isPartnerAdmin) {
 				String userId = getUserId();
 				List<Partner> partnerList = partnerServiceRepository.findByUserId(userId);

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -1424,14 +1424,8 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 				expiryEndDate = expiryStartDate.plusDays(filterDto.getExpiryPeriod()).with(LocalTime.MAX);
 			}
 
-			// Partner Admin: use request partnerType (null = all types). Non-admin: default to Auth_Partner when not set (partnerType filter only for Partner Admin).
-			String effectivePartnerType = filterDto.getPartnerType();
-			if (!isPartnerAdmin && effectivePartnerType == null) {
-				effectivePartnerType = PartnerConstants.AUTH_PARTNER_TYPE;
-			}
-
 			Page<ApiKeyRequestsSummaryEntity> page = apiKeyRequestSummaryRepository.getSummaryOfAllApiKeyRequests(
-					filterDto.getPartnerId(), effectivePartnerType, filterDto.getApiKeyLabel(), filterDto.getOrgName(), filterDto.getPolicyName(),
+					filterDto.getPartnerId(), partnerType, filterDto.getApiKeyLabel(), filterDto.getOrgName(), filterDto.getPolicyName(),
 					filterDto.getPolicyGroupName(), filterDto.getStatus(), partnerIdList, isPartnerAdmin, expiryStartDate,
 					expiryEndDate, filterDto.getExpiryPeriod(), pageable
 			);

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -1420,7 +1420,6 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 				expiryEndDate = expiryStartDate.plusDays(filterDto.getExpiryPeriod()).with(LocalTime.MAX);
 			}
 
-			// Old endpoint: filter by Auth_Partner only. V2 Partner Admin: honour request partnerType. V2 non-admin (Auth Partner): set internally to Auth_Partner (partnerType filter is only for Partner Admin).
 			String effectivePartnerType;
 			if (dtoClass == ApiKeyRequestSummaryDto.class) {
 				effectivePartnerType = PartnerConstants.AUTH_PARTNER_TYPE;

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -9,7 +9,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -1380,19 +1379,6 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 			boolean isPartnerAdmin = partnerHelper.isPartnerAdmin(authUserDetails().getAuthorities().toString());
 			String partnerType = filterDto.getPartnerType();
 			List<String> partnerIdList = null;
-			if (partnerType != null && !partnerType.isBlank()) {
-				List<String> validPartnerTypes = List.of(
-						PartnerConstants.AUTH_PARTNER_TYPE.toLowerCase(),
-						PartnerConstants.MANUAL_ADJUDICATION_PARTNER_TYPE.toLowerCase());
-				if (!validPartnerTypes.contains(partnerType)) {
-					pageResponseV2Dto.setPageNo(pageNo != null ? pageNo : 0);
-					pageResponseV2Dto.setPageSize(pageSize != null ? pageSize : 0);
-					pageResponseV2Dto.setTotalResults(0L);
-					pageResponseV2Dto.setData(Collections.emptyList());
-					responseWrapper.setResponse(pageResponseV2Dto);
-					return responseWrapper;
-				}
-			}
 
 			if (!isPartnerAdmin) {
 				String userId = getUserId();

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -1420,8 +1420,18 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 				expiryEndDate = expiryStartDate.plusDays(filterDto.getExpiryPeriod()).with(LocalTime.MAX);
 			}
 
+			// Old endpoint: filter by Auth_Partner only. V2 Partner Admin: honour request partnerType. V2 non-admin (Auth Partner): set internally to Auth_Partner (partnerType filter is only for Partner Admin).
+			String effectivePartnerType;
+			if (dtoClass == ApiKeyRequestSummaryDto.class) {
+				effectivePartnerType = PartnerConstants.AUTH_PARTNER_TYPE;
+			} else if (isPartnerAdmin) {
+				effectivePartnerType = filterDto.getPartnerType();
+			} else {
+				effectivePartnerType = PartnerConstants.AUTH_PARTNER_TYPE;
+			}
+
 			Page<ApiKeyRequestsSummaryEntity> page = apiKeyRequestSummaryRepository.getSummaryOfAllApiKeyRequests(
-					filterDto.getPartnerId(), filterDto.getPartnerType(), filterDto.getApiKeyLabel(), filterDto.getOrgName(), filterDto.getPolicyName(),
+					filterDto.getPartnerId(), effectivePartnerType, filterDto.getApiKeyLabel(), filterDto.getOrgName(), filterDto.getPolicyName(),
 					filterDto.getPolicyGroupName(), filterDto.getStatus(), partnerIdList, isPartnerAdmin, expiryStartDate,
 					expiryEndDate, filterDto.getExpiryPeriod(), pageable
 			);

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -1420,12 +1420,9 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 				expiryEndDate = expiryStartDate.plusDays(filterDto.getExpiryPeriod()).with(LocalTime.MAX);
 			}
 
-			String effectivePartnerType;
-			if (dtoClass == ApiKeyRequestSummaryDto.class) {
-				effectivePartnerType = PartnerConstants.AUTH_PARTNER_TYPE;
-			} else if (isPartnerAdmin) {
-				effectivePartnerType = filterDto.getPartnerType();
-			} else {
+			// Partner Admin: use request partnerType (null = all types). Non-admin: default to Auth_Partner when not set (partnerType filter only for Partner Admin).
+			String effectivePartnerType = filterDto.getPartnerType();
+			if (!isPartnerAdmin && effectivePartnerType == null) {
 				effectivePartnerType = PartnerConstants.AUTH_PARTNER_TYPE;
 			}
 

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -1386,9 +1386,6 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 						io.mosip.pms.partner.constant.ErrorCode.PARTNER_TYPE_FILTER_NOT_ALLOWED.getErrorMessage());
 			}
 
-			if (isPartnerAdmin && partnerType == null) {
-				partnerType = PartnerConstants.AUTH_PARTNER_TYPE.toLowerCase();
-			}
 			if (!isPartnerAdmin) {
 				String userId = getUserId();
 				List<Partner> partnerList = partnerServiceRepository.findByUserId(userId);
@@ -1399,6 +1396,8 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 				}
 				partnerIdList = new ArrayList<>();
 				for (Partner partner : partnerList) {
+					partnerHelper.validatePartnerId(partner, userId);
+					partnerHelper.validatePolicyGroupId(partner, userId);
 					partnerIdList.add(partner.getId());
 				}
 			}

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -1377,7 +1377,14 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 			PageResponseV2Dto<D> pageResponseV2Dto = new PageResponseV2Dto<>();
 			partnerHelper.validateRequestParameters(partnerHelper.apiKeyAliasToColumnMap, sortFieldName, sortType, pageNo, pageSize);
 			boolean isPartnerAdmin = partnerHelper.isPartnerAdmin(authUserDetails().getAuthorities().toString());
+			String partnerType = filterDto.getPartnerType();
 			List<String> partnerIdList = null;
+			if (partnerType != null && !isPartnerAdmin) {
+				LOGGER.error("Non-admin user attempted to filter by partnerType. Only PARTNER_ADMIN can use this filter.");
+				throw new PartnerServiceException(
+						io.mosip.pms.partner.constant.ErrorCode.PARTNER_TYPE_FILTER_NOT_ALLOWED.getErrorCode(),
+						io.mosip.pms.partner.constant.ErrorCode.PARTNER_TYPE_FILTER_NOT_ALLOWED.getErrorMessage());
+			}
 			if (!isPartnerAdmin) {
 				String userId = getUserId();
 				List<Partner> partnerList = partnerServiceRepository.findByUserId(userId);
@@ -1388,9 +1395,6 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 				}
 				partnerIdList = new ArrayList<>();
 				for (Partner partner : partnerList) {
-					partnerHelper.validatePartnerId(partner, userId);
-					partnerHelper.validatePolicyGroupId(partner, userId);
-					partnerHelper.validatePolicyGroup(partner);
 					partnerIdList.add(partner.getId());
 				}
 			}

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -1386,6 +1386,15 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 						io.mosip.pms.partner.constant.ErrorCode.PARTNER_TYPE_FILTER_NOT_ALLOWED.getErrorMessage());
 			}
 
+			if (isPartnerAdmin && partnerType != null) {
+				List<String> validPartnerTypes = List.of(PartnerConstants.AUTH_PARTNER_TYPE.toLowerCase(), PartnerConstants.MANUAL_ADJUDICATION_PARTNER_TYPE.toLowerCase());
+				if (!validPartnerTypes.contains(partnerType)) {
+					throw new PartnerServiceException(
+							io.mosip.pms.partner.constant.ErrorCode.INVALID_PARTNER_TYPE_FOR_FILTER.getErrorCode(),
+							String.format(io.mosip.pms.partner.constant.ErrorCode.INVALID_PARTNER_TYPE_FOR_FILTER.getErrorMessage(), partnerType));
+				}
+			}
+
 			if (!isPartnerAdmin) {
 				String userId = getUserId();
 				List<Partner> partnerList = partnerServiceRepository.findByUserId(userId);

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -9,6 +9,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -1379,19 +1380,17 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 			boolean isPartnerAdmin = partnerHelper.isPartnerAdmin(authUserDetails().getAuthorities().toString());
 			String partnerType = filterDto.getPartnerType();
 			List<String> partnerIdList = null;
-			if (partnerType != null && !isPartnerAdmin) {
-				LOGGER.error("Non-admin user attempted to filter by partnerType. Only PARTNER_ADMIN can use this filter.");
-				throw new PartnerServiceException(
-						io.mosip.pms.partner.constant.ErrorCode.PARTNER_TYPE_FILTER_NOT_ALLOWED.getErrorCode(),
-						io.mosip.pms.partner.constant.ErrorCode.PARTNER_TYPE_FILTER_NOT_ALLOWED.getErrorMessage());
-			}
-
-			if (isPartnerAdmin && partnerType != null) {
-				List<String> validPartnerTypes = List.of(PartnerConstants.AUTH_PARTNER_TYPE.toLowerCase(), PartnerConstants.MANUAL_ADJUDICATION_PARTNER_TYPE.toLowerCase());
+			if (partnerType != null && !partnerType.isBlank()) {
+				List<String> validPartnerTypes = List.of(
+						PartnerConstants.AUTH_PARTNER_TYPE.toLowerCase(),
+						PartnerConstants.MANUAL_ADJUDICATION_PARTNER_TYPE.toLowerCase());
 				if (!validPartnerTypes.contains(partnerType)) {
-					throw new PartnerServiceException(
-							io.mosip.pms.partner.constant.ErrorCode.INVALID_PARTNER_TYPE_FOR_FILTER.getErrorCode(),
-							String.format(io.mosip.pms.partner.constant.ErrorCode.INVALID_PARTNER_TYPE_FOR_FILTER.getErrorMessage(), partnerType));
+					pageResponseV2Dto.setPageNo(pageNo != null ? pageNo : 0);
+					pageResponseV2Dto.setPageSize(pageSize != null ? pageSize : 0);
+					pageResponseV2Dto.setTotalResults(0L);
+					pageResponseV2Dto.setData(Collections.emptyList());
+					responseWrapper.setResponse(pageResponseV2Dto);
+					return responseWrapper;
 				}
 			}
 

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -1421,7 +1421,7 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 			}
 
 			Page<ApiKeyRequestsSummaryEntity> page = apiKeyRequestSummaryRepository.getSummaryOfAllApiKeyRequests(
-					filterDto.getPartnerId(), filterDto.getApiKeyLabel(), filterDto.getOrgName(), filterDto.getPolicyName(),
+					filterDto.getPartnerId(), filterDto.getPartnerType(), filterDto.getApiKeyLabel(), filterDto.getOrgName(), filterDto.getPolicyName(),
 					filterDto.getPolicyGroupName(), filterDto.getStatus(), partnerIdList, isPartnerAdmin, expiryStartDate,
 					expiryEndDate, filterDto.getExpiryPeriod(), pageable
 			);

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/util/PartnerHelper.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/util/PartnerHelper.java
@@ -95,6 +95,7 @@ public class PartnerHelper {
     public final Map<String, String> apiKeyAliasToColumnMap = new HashMap<>();
     {
         apiKeyAliasToColumnMap.put("partnerId", "partnerId");
+        apiKeyAliasToColumnMap.put("partnerType", "p.partnerTypeCode");
         apiKeyAliasToColumnMap.put("apiKeyLabel", "label");
         apiKeyAliasToColumnMap.put("orgName", "p.name");
         apiKeyAliasToColumnMap.put("policyName", "ap.name");

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerManagementControllerTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerManagementControllerTest.java
@@ -462,9 +462,9 @@ public class PartnerManagementControllerTest {
 		Integer pageNo = 0;
 		Integer pageSize = 8;
 		ApiKeyFilterDto apiKeyFilterDto = new ApiKeyFilterDto();
-		ResponseWrapperV2<PageResponseV2Dto<ApiKeyRequestSummaryDto>> responseWrapper = new ResponseWrapperV2<>();
+		ResponseWrapperV2<PageResponseV2Dto<ApiKeyRequestSummaryV2Dto>> responseWrapper = new ResponseWrapperV2<>();
 
-		Mockito.when(partnerManagementService.getAllApiKeyRequests(sortFieldName, sortType, pageNo, pageSize, apiKeyFilterDto))
+		Mockito.when(partnerManagementService.getAllApiKeyRequestsV2(sortFieldName, sortType, pageNo, pageSize, apiKeyFilterDto))
 				.thenReturn(responseWrapper);
 		mockMvc.perform(MockMvcRequestBuilders.get("/partner-api-keys/v2")
 						.param("sortFieldName", sortFieldName)
@@ -476,7 +476,8 @@ public class PartnerManagementControllerTest {
 						.param("orgName", "ABC")
 						.param("status", "approved")
 						.param("policyName", "policy name")
-						.param("policyGroupName", "policy group"))
+						.param("policyGroupName", "policy group")
+						.param("partnerType", "Auth_Partner"))
 				.andExpect(MockMvcResultMatchers.status().isOk());
 	}
 
@@ -488,9 +489,9 @@ public class PartnerManagementControllerTest {
 		Integer pageNo = 0;
 		Integer pageSize = 8;
 		ApiKeyFilterDto apiKeyFilterDto = new ApiKeyFilterDto();
-		ResponseWrapperV2<PageResponseV2Dto<ApiKeyRequestSummaryDto>> responseWrapper = new ResponseWrapperV2<>();
+		ResponseWrapperV2<PageResponseV2Dto<ApiKeyRequestSummaryV2Dto>> responseWrapper = new ResponseWrapperV2<>();
 
-		Mockito.when(partnerManagementService.getAllApiKeyRequests(sortFieldName, sortType, pageNo, pageSize, apiKeyFilterDto))
+		Mockito.when(partnerManagementService.getAllApiKeyRequestsV2(sortFieldName, sortType, pageNo, pageSize, apiKeyFilterDto))
 				.thenReturn(responseWrapper);
 		mockMvc.perform(MockMvcRequestBuilders.get("/partner-api-keys/v2")
 						.param("sortFieldName", sortFieldName)

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/service/impl/PartnerManagementServiceImplTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/service/impl/PartnerManagementServiceImplTest.java
@@ -1645,7 +1645,7 @@ public class PartnerManagementServiceImplTest {
 		apiKeyRequestsSummaryEntity.setApiKeyId("12345");
 		Page<ApiKeyRequestsSummaryEntity> page = new PageImpl<>(List.of(apiKeyRequestsSummaryEntity), pageable, 1);
 
-		when(apiKeyRequestSummaryRepository.getSummaryOfAllApiKeyRequests(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyList(), anyBoolean(), any(), any(), any(), any())).thenReturn(page);
+		when(apiKeyRequestSummaryRepository.getSummaryOfAllApiKeyRequests(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyList(), anyBoolean(), any(), any(), any(), any())).thenReturn(page);
 		partnerManagementImpl.getAllApiKeyRequests(sortFieldName, sortType, pageNo, pageSize, apiKeyFilterDto);
 	}
 
@@ -1692,7 +1692,7 @@ public class PartnerManagementServiceImplTest {
 		apiKeyRequestsSummaryEntity.setApiKeyId("12345");
 		Page<ApiKeyRequestsSummaryEntity> page = new PageImpl<>(List.of(apiKeyRequestsSummaryEntity), pageable, 1);
 
-		when(apiKeyRequestSummaryRepository.getSummaryOfAllApiKeyRequests(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyList(), anyBoolean(), any(), any(), any(), any())).thenReturn(page);
+		when(apiKeyRequestSummaryRepository.getSummaryOfAllApiKeyRequests(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyList(), anyBoolean(), any(), any(), any(), any())).thenReturn(page);
 		partnerManagementImpl.getAllApiKeyRequestsV2(sortFieldName, sortType, pageNo, pageSize, apiKeyFilterDto);
 	}
 

--- a/partner/pms-common/src/main/java/io/mosip/pms/common/entity/ApiKeyRequestsSummaryEntity.java
+++ b/partner/pms-common/src/main/java/io/mosip/pms/common/entity/ApiKeyRequestsSummaryEntity.java
@@ -27,6 +27,7 @@ import java.util.Date;
                                 @ColumnResult(name = "policyGroupId", type = String.class),
                                 @ColumnResult(name = "policyGroupName", type = String.class),
                                 @ColumnResult(name = "policyGroupDescription", type = String.class),
+                                @ColumnResult(name = "partnerType", type = String.class),
                                 @ColumnResult(name = "status", type = String.class),
                                 @ColumnResult(name = "createdDateTime", type = Date.class),
                                 @ColumnResult(name = "apiKeyExpiryDateTime", type = Date.class),
@@ -40,7 +41,7 @@ public class ApiKeyRequestsSummaryEntity {
     public ApiKeyRequestsSummaryEntity(
             String apiKeyId, String partnerId, String apiKeyLabel, String orgName, String policyId,
             String policyName, String policyDescription, String policyGroupId, String policyGroupName, String policyGroupDescription,
-            String status, Date createdDateTime, Date apiKeyExpiryDateTime, Boolean isApiKeyExpiredStatus) {
+            String partnerType, String status, Date createdDateTime, Date apiKeyExpiryDateTime, Boolean isApiKeyExpiredStatus) {
         this.apiKeyId = apiKeyId;
         this.partnerId = partnerId;
         this.apiKeyLabel = apiKeyLabel;
@@ -51,6 +52,7 @@ public class ApiKeyRequestsSummaryEntity {
         this.policyGroupId = policyGroupId;
         this.policyGroupDescription = policyGroupDescription;
         this.policyGroupName = policyGroupName;
+        this.partnerType = partnerType;
         this.status = status;
         this.createdDateTime = createdDateTime;
         this.apiKeyExpiryDateTime = apiKeyExpiryDateTime;
@@ -82,6 +84,8 @@ public class ApiKeyRequestsSummaryEntity {
     private String policyGroupName;
 
     private String policyGroupDescription;
+
+    private String partnerType;
 
     private String status;
 

--- a/partner/pms-common/src/main/java/io/mosip/pms/common/repository/ApiKeyRequestSummaryRepository.java
+++ b/partner/pms-common/src/main/java/io/mosip/pms/common/repository/ApiKeyRequestSummaryRepository.java
@@ -16,6 +16,7 @@ public interface ApiKeyRequestSummaryRepository extends BaseRepository<ApiKeyReq
 
     @Query(value = "SELECT new io.mosip.pms.common.entity.ApiKeyRequestsSummaryEntity(" +
             "pp.apiKeyId, pp.partnerId, pp.label, p.name, pp.policyId, ap.name, ap.descr, pg.id, pg.name, pg.desc, " +
+            "p.partnerTypeCode, " +
             "CASE " +
             "WHEN pp.isActive = false THEN 'deactivated' " +
             "WHEN pp.isActive = true THEN 'activated' " +
@@ -30,7 +31,7 @@ public interface ApiKeyRequestSummaryRepository extends BaseRepository<ApiKeyReq
             "LEFT JOIN pp.policy ap " +
             "LEFT JOIN ap.policyGroup pg " +
             "WHERE (:partnerId IS NULL OR lower(pp.partnerId) LIKE %:partnerId%) " +
-            "AND (p.partnerTypeCode = 'Auth_Partner') " +
+            "AND (:partnerType IS NULL OR p.partnerTypeCode = :partnerType) " +
             "AND (:apiKeyLabel IS NULL OR lower(pp.label) LIKE %:apiKeyLabel%) " +
             "AND (:orgName IS NULL OR lower(p.name) LIKE %:orgName%) " +
             "AND (:policyName IS NULL OR lower(ap.name) LIKE %:policyName%) " +
@@ -43,6 +44,7 @@ public interface ApiKeyRequestSummaryRepository extends BaseRepository<ApiKeyReq
     )
     Page<ApiKeyRequestsSummaryEntity> getSummaryOfAllApiKeyRequests(
             @Param("partnerId") String partnerId,
+            @Param("partnerType") String partnerType,
             @Param("apiKeyLabel") String apiKeyLabel,
             @Param("orgName") String orgName,
             @Param("policyName") String policyName,

--- a/partner/pms-common/src/main/java/io/mosip/pms/common/repository/ApiKeyRequestSummaryRepository.java
+++ b/partner/pms-common/src/main/java/io/mosip/pms/common/repository/ApiKeyRequestSummaryRepository.java
@@ -31,7 +31,7 @@ public interface ApiKeyRequestSummaryRepository extends BaseRepository<ApiKeyReq
             "LEFT JOIN pp.policy ap " +
             "LEFT JOIN ap.policyGroup pg " +
             "WHERE (:partnerId IS NULL OR lower(pp.partnerId) LIKE %:partnerId%) " +
-            "AND (:partnerType IS NULL OR p.partnerTypeCode = :partnerType) " +
+            "AND (:partnerType IS NULL OR lower(p.partnerTypeCode) = :partnerType) " +
             "AND (:apiKeyLabel IS NULL OR lower(pp.label) LIKE %:apiKeyLabel%) " +
             "AND (:orgName IS NULL OR lower(p.name) LIKE %:orgName%) " +
             "AND (:policyName IS NULL OR lower(ap.name) LIKE %:policyName%) " +


### PR DESCRIPTION
…artnerType in request filter and response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * V2 API key endpoint adds partnerType as a query filter and includes partnerType in each returned item for clearer classification.
  * Non-admin requests cannot use partnerType filtering; admin users may filter by partnerType.

* **Documentation**
  * Endpoint descriptions and examples updated to show the new partnerType field, filtering behavior, and admin-only restriction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->