### PR TITLE
MOSIP-44505: Fixed DBValidator failure by adding RUNCONTEXT for policy name in PMS.

### DIFF
--- a/api-test/src/main/resources/pms/DbValidatorTest/DbValidatorTest.yml
+++ b/api-test/src/main/resources/pms/DbValidatorTest/DbValidatorTest.yml
@@ -27,7 +27,7 @@ DBValidator:
       outputTemplate: pms/DbValidatorTest/DbValidatorResult
       input: '{
     "partner_id": "$REMOVE$",
-    "policy_name": "mosip data share policy",
+    "policy_name": "$RUNCONTEXT$mosip data share policy",
     "api_key_id": "$REMOVE$",
     "license_key": "$REMOVE$"
 }'


### PR DESCRIPTION
- Updated TC_PMS_DBValidator_02 testcase to use RUNCONTEXT for policy_name during DB validation.
- Policy data is dynamically created through automation with run context appended to avoid data collision across environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test data configuration to use context-based variable expansion for policy name parameters, enhancing test execution flexibility and control flow handling during test data generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->