### PR TITLE
[MOSIP-44442]: Used old error messages of API(/{partnerId}/generate/apikey)  for new API(/{partnerId}/policies/{policyId}/api-keys)

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/constant/ErrorCode.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/constant/ErrorCode.java
@@ -41,7 +41,6 @@ public enum ErrorCode {
 	CERTIFICATE_NOT_UPLOADED_EXCEPTION("PMS_PRT_108","Certficate is not uploaded for the given partner.Cannot activate the same."),
 	PARTNER_POLICY_MAPPING_NOT_EXISTS("PMS_PRT_109","Partner policy mapping is not approved for given partner and policy. Please check mapping status."),
 	PARTNER_POLICY_LABEL_EXISTS("PMS_PRT_110","Given label already exists.Provide unique label."),
-	PARTNER_POLICY_APIKEY_NAME_EXISTS("PMS_PRT_112","Given apiKeyName already exists. Provide unique apiKeyName."),
 	PARTNER_POLICY_LABEL_NOT_EXISTS("PMS_PRT_111","API key not exists for the given combination"),
 	LOGGEDIN_USER_NOT_AUTHORIZED("PMS_PRT_055","User not authorized."),
 	JSON_NOT_VALID("PMS_PRT_096","Json is not valid"),
@@ -78,7 +77,6 @@ public enum ErrorCode {
 	ENCRYPT_DATA_ERROR("PMS-BJ-014", "Failed to encrypt data using Key Manager"),
 	PARTNER_ADMIN_ONLY_FOR_MANUAL_ADJUDICATION("PMS_PM_074", "Partner Admin can only generate API keys on behalf of Manual Adjudication partners."),
 	PARTNER_TYPE_NOT_ELIGIBLE_FOR_API_KEY("PMS_PM_075", "The partner type is not eligible for API key generation via this endpoint."),
-	POLICY_NOT_BELONGS_TO_POLICY_GROUP("PMS_PM_076", "The given policy does not belong to the partner's policy group."),
 	GENERATE_API_KEY_ERROR("PMS_PM_077", "Error while generating API key.");
 	
 

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -757,12 +757,12 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
                 LOGGER.error("Policy {} does not belong to partner's policy group", policyId);
                 auditUtil.setAuditRequestDto(PartnerManageEnum.GENERATE_API_KEY_FAILURE, partnerId, "partnerId");
                 throw new PartnerManagerServiceException(
-                        ErrorCode.POLICY_NOT_BELONGS_TO_POLICY_GROUP.getErrorCode(),
-                        ErrorCode.POLICY_NOT_BELONGS_TO_POLICY_GROUP.getErrorMessage());
+                        "PMS_POL_015",
+                        "Policy group and policy not mapped.");
             }
 			String apiKeyName = PartnerUtil.trimAndReplace(request.getApiKeyName());
 			validateApiKeyNameNotExist(partnerId, authPolicy.getId(), apiKeyName,
-					ErrorCode.PARTNER_POLICY_APIKEY_NAME_EXISTS);
+					ErrorCode.PARTNER_POLICY_LABEL_EXISTS);
 
 			APIKeyGenerateResponseDto response = createApiKey(partnerId, authPolicy, apiKeyName);
 


### PR DESCRIPTION
…ge format for new API(/{partnerId}/policies/{policyId}/api-keys)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated error code handling in API key generation—error messages have been updated to use standardized codes for consistency when policy validation or duplicate key name scenarios occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->