### PR TITLE
MOSIP-44660 added pmp.allowed.credential.types

### DIFF
--- a/partner/partner-management-service/src/main/resources/application-dev.properties
+++ b/partner/partner-management-service/src/main/resources/application-dev.properties
@@ -39,7 +39,7 @@ logging.pattern.file=%d %p %c{1.} [%t] %m%n
 logging.pattern.console=%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
 
 websub.publish.url=${mosip.api.internal.url}/hub/
-pmp.allowed.credential.types=
+pmp.allowed.credential.types=auth,qrcode,euin,reprint,eUIN_with_faceQR,eUIN_with_QR,PDFCard,vercred
 policy.credential.type.mapping.allowed.partner.types=Credential_Partner,Online_Verification_Partner
 mosip.kernel.idgenerator.misp.license-key-length = 50
 mosip.pmp.misp.license.expiry.period.indays = 90

--- a/partner/partner-management-service/src/main/resources/application-dev.properties
+++ b/partner/partner-management-service/src/main/resources/application-dev.properties
@@ -39,6 +39,7 @@ logging.pattern.file=%d %p %c{1.} [%t] %m%n
 logging.pattern.console=%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
 
 websub.publish.url=${mosip.api.internal.url}/hub/
+## Allowed credential types which partner can map against to policy
 pmp.allowed.credential.types=auth,qrcode,euin,reprint,eUIN_with_faceQR,eUIN_with_QR,PDFCard,vercred
 policy.credential.type.mapping.allowed.partner.types=Credential_Partner,Online_Verification_Partner
 mosip.kernel.idgenerator.misp.license-key-length = 50


### PR DESCRIPTION
[MOSIP-44660]

[MOSIP-44660]: https://mosip.atlassian.net/browse/MOSIP-44660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured an explicit allowlist of supported credential types and added an inline description for it. Expanded recognized credential types to include authentication, QR codes, eUIN variants (including face-based QR), reprint, PDF card, and verified credentials for improved credential recognition and processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->