### PR TITLE
[MOSIP-44792] : Corrected behaviour of "/v1/policymanager/policies/{policyId}/partner/{partnerId}" to check for mapping in "partner_policy_request" table

### DIFF
--- a/partner/policy-management-service/src/main/java/io/mosip/pms/policy/service/PolicyManagementService.java
+++ b/partner/policy-management-service/src/main/java/io/mosip/pms/policy/service/PolicyManagementService.java
@@ -767,9 +767,10 @@ public class PolicyManagementService {
 	 */
 	public PolicyResponseDto getPartnerMappedPolicy(String partnerId, String policyId)
 			throws JsonParseException, JsonMappingException, IOException {
-		List<PartnerPolicy> partnerPolicy = partnerPolicyRepository.findByPartnerIdAndPolicyIdAndIsActiveTrue(partnerId, policyId);
-		if (partnerPolicy.isEmpty()) {
-			logger.error("Policy is not mapped for given partner {} and policy {}", partnerId, policyId);
+		List<PartnerPolicyRequest> partnerPolicyRequest = partnerPolicyRequestRepository
+				.findByPartnerIdAndPolicyIdAndStatusCode(partnerId, policyId, APPROVED);
+		if (partnerPolicyRequest.isEmpty()) {
+			logger.error("Policy is not mapped (approved) for given partner {} and policy {}", partnerId, policyId);
 			throw new PolicyManagementServiceException(ErrorMessages.NO_POLICY_AGAINST_PARTNER.getErrorCode(),
 					ErrorMessages.NO_POLICY_AGAINST_PARTNER.getErrorMessage());
 		}

--- a/partner/policy-management-service/src/test/java/io/mosip/pms/policy/test/service/PolicyServiceTest.java
+++ b/partner/policy-management-service/src/test/java/io/mosip/pms/policy/test/service/PolicyServiceTest.java
@@ -862,42 +862,41 @@ public class PolicyServiceTest {
 	
 	@Test(expected = PolicyManagementServiceException.class)
 	public void getPartnerMappedPolicy_NoPolicyTest() throws JsonParseException, JsonMappingException, IOException {
-		Mockito.when(partnerPolicyRepository.findByPartnerIdAndPolicyIdAndIsActiveTrue("2345","12345")).thenReturn(null);		
+		Mockito.when(partnerPolicyRequestRepository.findByPartnerIdAndPolicyIdAndStatusCode("12345", "12345", "approved"))
+				.thenReturn(new ArrayList<>());
 		service.getPartnerMappedPolicy("12345", "12345");
 	}
 	
 	@Test(expected = PolicyManagementServiceException.class)
 	public void getPartnerMappedPolicy_NoAuthPolicyTest() throws JsonParseException, JsonMappingException, IOException {
-		PartnerPolicy policy = new PartnerPolicy();
-		List<PartnerPolicy> partnerPolicy = new ArrayList<>();
+		PartnerPolicyRequest request = new PartnerPolicyRequest();
 		Partner partner = new Partner();
-		partner.setAddress("Test");
-		partner.setName("Test");
-		policy.setPartner(partner);
-		policy.getPartner().setId("12345");
-		policy.setPolicyId("12345");
-		policy.setPolicyApiKey("12345");
-		partnerPolicy.add(policy);
-		Mockito.when(partnerPolicyRepository.findByPartnerIdAndPolicyIdAndIsActiveTrue("12345","12345")).thenReturn(partnerPolicy);		
+		partner.setId("12345");
+		request.setPartner(partner);
+		request.setPolicyId("12345");
+		request.setStatusCode("approved");
+		List<PartnerPolicyRequest> partnerPolicyRequest = new ArrayList<>();
+		partnerPolicyRequest.add(request);
+		Mockito.when(partnerPolicyRequestRepository.findByPartnerIdAndPolicyIdAndStatusCode("12345", "12345", "approved"))
+				.thenReturn(partnerPolicyRequest);
 		service.getPartnerMappedPolicy("12345", "12345");
 	}
 	
 	@Test
 	public void getPartnerMappedPolicyTest_001() throws JsonParseException, JsonMappingException, IOException {
-		PartnerPolicy policy = new PartnerPolicy();
-		List<PartnerPolicy> partnerPolicy = new ArrayList<>();
+		PartnerPolicyRequest request = new PartnerPolicyRequest();
 		Partner partner = new Partner();
-		partner.setAddress("Test");
-		partner.setName("Test");
-		policy.setPartner(partner);
-		policy.getPartner().setId("12345");
-		policy.setPolicyId("12345");
-		policy.setPolicyApiKey("12345");
-		partnerPolicy.add(policy);
+		partner.setId("12345");
+		request.setPartner(partner);
+		request.setPolicyId("12345");
+		request.setStatusCode("approved");
+		List<PartnerPolicyRequest> partnerPolicyRequest = new ArrayList<>();
+		partnerPolicyRequest.add(request);
 		Optional<PolicyGroup> policyGroup = Optional.of(new PolicyGroup());
 		policyGroup.get().setId("12345");		
 		Mockito.when(policyGroupRepository.findById("12345")).thenReturn(policyGroup);
-		Mockito.when(partnerPolicyRepository.findByPartnerIdAndPolicyIdAndIsActiveTrue("12345","12345")).thenReturn(partnerPolicy);
+		Mockito.when(partnerPolicyRequestRepository.findByPartnerIdAndPolicyIdAndStatusCode("12345", "12345", "approved"))
+				.thenReturn(partnerPolicyRequest);
 		Mockito.when(authPolicyRepository.findById("12345")).thenReturn(Optional.of(getAuthPolicies().get(0)));
 		service.getPartnerMappedPolicy("12345", "12345");
 	}


### PR DESCRIPTION
…olicyId}/partner/{partnerId}" to check for mapping in "partner_policy_request" table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated partner policy lookup to validate against approved status instead of active flags, ensuring correct authorization checks for policy mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->