### PR TITLE
MOSIP-44709: Fixed HealthCheck module mapping by using normalized module name instead of prefixed identifier.

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/partner/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/partner/testrunner/MosipTestRunner.java
@@ -82,7 +82,7 @@ public class MosipTestRunner {
 			setLogLevels();
 
 			HealthChecker healthcheck = new HealthChecker();
-			healthcheck.setCurrentRunningModule(BaseTestCase.currentModule);
+			healthcheck.setCurrentRunningModule(GlobalConstants.PARTNER_MANAGEMENT_SERVICE);
 			Thread trigger = new Thread(healthcheck);
 			trigger.start();
 


### PR DESCRIPTION
Fixes HealthCheck module mismatch by replacing the prefixed module name (BaseTestCase.currentModule) with a normalized value (GlobalConstants.PMS), ensuring correct mapping with healthCheckEndpoint.properties and proper endpoint filtering.