### PR TITLE
[MOSIP-44660] added allowedCredentialTypes 

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/user/controller/UserController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/user/controller/UserController.java
@@ -87,6 +87,9 @@ public class UserController {
 	@Value("${mosip.pms.oidc.client.additional.info.required}")
 	private String isOidcClientAdditionalInfoRequired;
 
+	@Value("${pmp.allowed.credential.types}")
+	private String allowedCredentialTypes;
+
 	public static final String VERSION = "1.0";
 
 	@Autowired
@@ -154,6 +157,7 @@ public class UserController {
 		configMap.put("phoneNumberMaxLength", phoneNumberMaxLength);
 		configMap.put("supportedOidcLanguages", supportedOidcLanguages);
 		configMap.put("isOidcClientAdditionalInfoRequired", isOidcClientAdditionalInfoRequired);
+		configMap.put("allowedCredentialTypes", allowedCredentialTypes);
 		responseWrapper.setResponse(configMap);
 		System.out.println(responseWrapper);
 		return responseWrapper;


### PR DESCRIPTION
[MOSIP-44660] 

[MOSIP-44660]: https://mosip.atlassian.net/browse/MOSIP-44660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The system configuration endpoint response now includes credential type information, enabling clients to retrieve allowed credential types alongside other system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->