### PR TITLE
MOSIP-44744: Added test coverage for GET /partner-api-keys/v2 endpoint for Manual Adjudication partner type.

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.5.0-SNAPSHOT</version>
+			<version>1.6.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/api-test/src/main/resources/pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner.hbs
+++ b/api-test/src/main/resources/pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner.hbs
@@ -1,0 +1,14 @@
+{
+	"apiKeyLabel": "{{apiKeyLabel}}",
+	"expiryPeriod": "{{expiryPeriod}}",
+	"orgName": "{{orgName}}",
+	"pageNo": "{{pageNo}}",
+	"pageSize": "{{pageSize}}",
+	"partnerId": "{{partnerId}}",
+	"partnerType": "{{partnerType}}",
+	"policyGroupName": "{{policyGroupName}}",
+	"policyName": "{{policyName}}",
+	"sortFieldName": "{{sortFieldName}}",
+	"sortType": "{{sortType}}",
+	"status": "{{status}}"
+}

--- a/api-test/src/main/resources/pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner.yml
+++ b/api-test/src/main/resources/pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner.yml
@@ -1,0 +1,498 @@
+GetAllApiKeyForMAPartnerV2:
+  Pms_GetAllApiKeyForMAPartnerV2_All_Valid_Smoke:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_01
+    description: Validate that all API keys are successfully retrieved for an MA partner using the V2 API with valid inputs
+    role: partneradmin
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartnerResult
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "Manual_Adjudication",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "pageNo": "0"
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_Token_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_02
+    description: Verify that API returns an authentication error when an invalid token is used to fetch API keys for an MA partner.
+    role: invalidtoken
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/error
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "Manual_Adjudication",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "errors": [
+        {
+           "errorCode": "KER-ATH-401"
+        }
+     ]
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_AuthPartner_Role:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_03
+    description: Verify that API keys are successfully retrieved for an MA partner using V2 API with partnerauth role.
+    role: partnerauth
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartnerResult
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "Manual_Adjudication",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "pageNo": "0"
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_DevicePartner_Token_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_04
+    description: Verify that API returns an authorization error when a device partner token is used to fetch API keys for an MA partner.
+    role: partnerdevice
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/error
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "Manual_Adjudication",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "errors": [
+        {
+           "errorCode": "KER-ATH-403"
+        }
+     ]
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_FTMPartner_Token_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_05
+    description: Verify that API returns an authorization error when an FTM partner token is used to fetch API keys for an MA partner.
+    role: partnerftm
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/error
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "Manual_Adjudication",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "errors": [
+        {
+           "errorCode": "KER-ATH-403"
+        }
+     ]
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_SortFieldName_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_06
+    description: Verify that API returns a request validation error when an invalid sort field name is provided.
+    role: partneradmin
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/error
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "$REMOVE$",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "@%orgName",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "errors": [
+        {
+           "errorCode": "PMS_REQUEST_ERROR_007"
+        }
+     ]
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_SortType_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_07
+    description: Verify that API returns a request validation error when an invalid sort type is provided.
+    role: partneradmin
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/error
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "$REMOVE$",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$@%asc",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "errors": [
+        {
+           "errorCode": "PMS_REQUEST_ERROR_007"
+        }
+     ]
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_SortType_And_SortFieldName_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_08
+    description: Verify that API returns a request validation error when both sort field name and sort type are invalid.
+    role: partneradmin
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/error
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "$REMOVE$",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "@%orgName",
+      "sortType": "$@%asc",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "errors": [
+        {
+           "errorCode": "PMS_REQUEST_ERROR_007"
+        }
+     ]
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_PageNo_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_09
+    description: Verify that API returns a bad request response when an invalid page number is provided.
+    role: partneradmin
+    checkOnlyStatusCodeInResponse: true
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/responseCode
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "invalid",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "Manual_Adjudication",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "responseCode": "400"
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_PageSize_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_10
+    description: Verify that API returns a bad request response when an invalid page size is provided.
+    role: partneradmin
+    checkOnlyStatusCodeInResponse: true
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/responseCode
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "invalid",
+      "partnerId": "$REMOVE$",
+      "partnerType": "Manual_Adjudication",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "responseCode": "400"
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Valid_PartnerId:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_11
+    description: Verify that API keys are successfully retrieved when a valid partner ID is provided for an MA partner.
+    role: partneradmin
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartnerResult
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$ID:CreateMAPartner_All_Valid_Smoke_Sid_partnerId$",
+      "partnerType": "Manual_Adjudication",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "pageNo": "0"
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_PartnerId_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_12
+    description: Verify that API returns a validation error when an invalid partner ID is provided in the request.
+    role: partneradmin
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/error
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "@%Invalid",
+      "partnerType": "$REMOVE$",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "errors": [
+        {
+           "errorCode": "PMS_REQUEST_ERROR_007"
+        }
+     ]
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_ApiKeyLabel_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_13
+    description: Verify that API returns a validation error when an invalid API key label is provided in the request.
+    role: partneradmin
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/error
+    input: '{
+      "apiKeyLabel": "@%apikeylabel",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "$REMOVE$",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "errors": [
+        {
+           "errorCode": "PMS_REQUEST_ERROR_007"
+        }
+     ]
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_OrgName_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_14
+    description: Verify that API returns a validation error when an invalid organization name is provided in the request.
+    role: partneradmin
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/error
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "@%OrgName",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "$REMOVE$",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "errors": [
+        {
+           "errorCode": "PMS_REQUEST_ERROR_007"
+        }
+     ]
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_PolicyName_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_15
+    description: Verify that API returns a validation error when an invalid policy name is provided in the request.
+    role: partneradmin
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/error
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "$REMOVE$",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "@%policyName",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "errors": [
+        {
+           "errorCode": "PMS_REQUEST_ERROR_007"
+        }
+     ]
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_PolicyGroupName_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_16
+    description: Verify that API returns a validation error when an invalid policy group name is provided in the request.
+    role: partneradmin
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/error
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "$REMOVE$",
+      "policyGroupName": "@%policyGroupName",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "errors": [
+        {
+           "errorCode": "PMS_REQUEST_ERROR_007"
+        }
+     ]
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_PartnerType_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_17
+    description: Verify that when an invalid partner type is provided, the API returns a successful response with no data (zero records)
+    role: partneradmin
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartnerResult
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "$REMOVE$",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "invalid",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "pageNo": "0"
+}'
+  Pms_GetAllApiKeyForMAPartnerV2_With_Invalid_ExpiryPeriod_Neg:
+    endPoint: /v1/partnermanager/partner-api-keys/v2
+    uniqueIdentifier: TC_PMS_GetAllApiKeyForMAPartnerV2_18
+    description: Verify that API returns a bad request response when an invalid expiry period is provided.
+    role: partneradmin
+    checkOnlyStatusCodeInResponse: true
+    restMethod: get
+    inputTemplate: pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner
+    outputTemplate: pms/responseCode
+    input: '{
+      "apiKeyLabel": "$REMOVE$",
+      "expiryPeriod": "@abc%",
+      "orgName": "$REMOVE$",
+      "pageNo": "$REMOVE$",
+      "pageSize": "$REMOVE$",
+      "partnerId": "$REMOVE$",
+      "partnerType": "$REMOVE$",
+      "policyGroupName": "$REMOVE$",
+      "policyName": "$REMOVE$",
+      "sortFieldName": "$REMOVE$",
+      "sortType": "$REMOVE$",
+      "status": "$REMOVE$"
+    }'
+    output: '{
+      "responseCode": "400"
+}'

--- a/api-test/src/main/resources/pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartnerResult.hbs
+++ b/api-test/src/main/resources/pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartnerResult.hbs
@@ -1,0 +1,12 @@
+{
+  "response": {
+    "pageNo": {{#if pageNo}}{{pageNo}}{{else}}0{{/if}},
+    "data": [
+      {{#each response.data}}
+      {
+        "partnerType": "{{this.partnerType}}"
+      }{{#unless @last}},{{/unless}}
+      {{/each}}
+    ]
+  }
+}

--- a/api-test/testNgXmlFiles/pmsSuite.xml
+++ b/api-test/testNgXmlFiles/pmsSuite.xml
@@ -328,6 +328,39 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithQueryParam" />
 		</classes>
 	</test>
+	<test name="MAPartnerV3">
+		<parameter name="ymlFile"
+			value="pms/MAPartnerV3/CreateMAPartner/CreateMAPartner.yml" />
+			<parameter name="idKeyName" value="id,partnerId" />
+		<classes>
+			<class
+				name="io.mosip.testrig.apirig.partner.testscripts.SimplePostForAutoGenId" />
+		</classes>
+	</test>
+	<test name="UploadCertificateCASUBCAForMA">
+		<parameter name="ymlFile"
+			value="pms/MAPartnerV3/UploadCertificateForMAPartner/UploadCertificateMAForCASUBCA.yml" />
+		<classes>
+			<class
+				name="io.mosip.testrig.apirig.partner.testscripts.SimplePost" />
+		</classes>
+	</test>
+	<test name="UploadMAPartnerCertificate">
+		<parameter name="ymlFile"
+			value="pms/MAPartnerV3/UploadPartnerCertificateForMAPartner/UploadMAPartnerCertificate.yml" />
+		<classes>
+			<class
+				name="io.mosip.testrig.apirig.partner.testscripts.SimplePost" />
+		</classes>
+	</test>
+	<test name="GetListofPartnersAssociatedwithLoggedinUserMA">
+		<parameter name="ymlFile"
+			value="pms/MAPartnerV3/GetListofPartnersAssociatedwithLoggedinUserMA/GetListofPartnersAssociatedwithLoggedinUserMA.yml" />
+		<classes>
+			<class
+				name="io.mosip.testrig.apirig.partner.testscripts.GetWithQueryParam" />
+		</classes>
+	</test>
 	<test name="CreatePartner_Online_Verification_Partner">
 		<parameter name="ymlFile"
 			value="pms/credentialPartner/CreatePartner/CreatePartner.yml" />
@@ -415,6 +448,14 @@
 		<classes>
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
+		</classes>
+	</test>
+	<test name="GetAllApiKeyForMAPartnerV2">
+		<parameter name="ymlFile"
+			value="pms/GetAllApiKeyForMAPartner/GetAllApiKeyForMAPartner.yml" />
+		<classes>
+			<class
+				name="io.mosip.testrig.apirig.partner.testscripts.GetWithQueryParam" />
 		</classes>
 	</test>
 
@@ -622,10 +663,10 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.PatchWithPathParamsAndBody" />
 		</classes>
 	</test>
-	<!-- PATCH /partners/{partnerId}/policy/{policyId}/apiKey/expiry-date has 
+	PATCH /partners/{partnerId}/policy/{policyId}/apiKey/expiry-date has 
 		been deprecated and replaced by PATCH /partners/{partnerId}/policies/{policyId}/api-keys/{apiKeyName}. 
-		Ticket ID: MOSIP-43700, Story ID: MOSIP-44155 -->
-	<!-- <test name="UpdateApiKeyExpiryDate">
+		Ticket ID: MOSIP-43700, Story ID: MOSIP-44155
+	<test name="UpdateApiKeyExpiryDate">
 		<parameter name="ymlFile"
 			value="pms/UpdateApiKeyExpiryDate/UpdateApiKeyExpiryDate.yml" />
 		<parameter name="pathParams" value="partnerId,policyId" />
@@ -642,11 +683,11 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.PatchWithPathParamsAndBody" />
 		</classes>
-	</test> -->
-	<!-- PATCH /partners/{partnerId}/policy/{policyId}/apiKey/status has 
+	</test>
+	PATCH /partners/{partnerId}/policy/{policyId}/apiKey/status has 
 		been deprecated and replaced by PATCH /partners/{partnerId}/policies/{policyId}/api-keys/{apiKeyName}. 
-		Ticket ID: MOSIP-44170, Story ID: MOSIP-44155 -->
-	<!--<test name="ActivateDeactivatePartnerApiKey">
+		Ticket ID: MOSIP-44170, Story ID: MOSIP-44155
+	<test name="ActivateDeactivatePartnerApiKey">
 		<parameter name="ymlFile"
 			value="pms/ActivateDeactivatePartnerApiKey/ActivateDeactivatePartnerApiKey.yml" />
 		<parameter name="pathParams" value="partnerId,policyId" />
@@ -654,7 +695,7 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.PatchWithPathParamsAndBody" />
 		</classes>
-	</test>-->
+	</test>
 	<test name="InsertDBData">
 		<parameter name="ymlFile"
 			value="pms/InsertDBData/InsertAPIKeyData.yml" />
@@ -966,7 +1007,7 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
 	</test>
-	<!-- POST /partners/search has been deprecated from release 1.2.2.0 onwards,
+	POST /partners/search has been deprecated from release 1.2.2.0 onwards,
 	replaced by GET /admin-partners with updated test cases.
 	<test name="SearchPartner">
 		<parameter name="ymlFile"
@@ -975,7 +1016,7 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.SimplePost" />
 		</classes>
-	</test> -->
+	</test>
 	<test name="CreateDeviceDetail">
 		<parameter name="ymlFile"
 			value="pms/device/makeAndModel/create/CreateDeviceDetail.yml" />
@@ -1570,7 +1611,7 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.DownloadRootCertificate" />
 		</classes>
 	</test>
-	<!-- POST /misps has been deprecated from release 1.3.x onwards, replaced
+	POST /misps has been deprecated from release 1.3.x onwards, replaced
 	by POST /misp-licenses with updated test cases. added in POST
 	/misp-licenses, Ticket ID: MOSIP-43118
 	<test name="CreateMispLicense">
@@ -1581,7 +1622,7 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.SimplePostForAutoGenId" />
 		</classes>
-	</test>  -->
+	</test> 
 	<test name="GenerateMISPPartnerLicense">
 		<parameter name="ymlFile"
 			value="pms/MispLicenseV3/GenerateMISPPartnerLicense/GenerateMISPPartnerLicense.yml" />
@@ -1654,7 +1695,7 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
 	</test>
-	<!-- GET /misps has been deprecated from release 1.3.x onwards, replaced
+	GET /misps has been deprecated from release 1.3.x onwards, replaced
 	by GET /misp-licenses with updated test cases. added in GET
 	/misp-licenses, Ticket ID: MOSIP-43118
 	<test name="GetMispLicense">
@@ -1664,8 +1705,8 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
-	</test>  -->
-	<!-- PUT /misps has been deprecated from release 1.3.x onwards, replaced
+	</test> 
+	PUT /misps has been deprecated from release 1.3.x onwards, replaced
 	by PUT /misp-licenses/{partnerId} with updated test cases. added in PUT
 	/misp-licenses/{partnerId}
 	Ticket ID: MOSIP-43118
@@ -1676,8 +1717,8 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.SimplePut" />
 		</classes>
-	</test> -->
-	<!-- GET /misps/{mispId}/licenseKey has been deprecated from release 1.3.x
+	</test>
+	GET /misps/{mispId}/licenseKey has been deprecated from release 1.3.x
 	onwards, replaced by GET /misp-licenses/{partnerId} with updated test
 	cases.
 	added in GET /misp-licenses/{partnerId} Ticket ID: MOSIP-43118
@@ -1688,7 +1729,7 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
-	</test>  -->
+	</test> 
 	<test name="SearchMispLicense">
 		<parameter name="ymlFile"
 			value="pms/MispLicense/SearchMispLicense/SearchMispLicense.yml" />
@@ -1755,7 +1796,7 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
 	</test>
-	<!-- GET /partners has been deprecated from release 1.2.2.0 onwards,
+	GET /partners has been deprecated from release 1.2.2.0 onwards,
 	replaced
 	by GET /admin-partners with updated test cases. added in GET
 	/admin-partners
@@ -1766,7 +1807,7 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
-	</test> -->
+	</test>
 	<test name="ActivateDeactivatePartner">
 		<parameter name="ymlFile"
 			value="pms/ActivateDeactivatePartner/ActivateDeactivatePartner.yml" />

--- a/api-test/testNgXmlFiles/pmsSuite.xml
+++ b/api-test/testNgXmlFiles/pmsSuite.xml
@@ -663,10 +663,10 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.PatchWithPathParamsAndBody" />
 		</classes>
 	</test>
-	PATCH /partners/{partnerId}/policy/{policyId}/apiKey/expiry-date has 
+	<!-- PATCH /partners/{partnerId}/policy/{policyId}/apiKey/expiry-date has 
 		been deprecated and replaced by PATCH /partners/{partnerId}/policies/{policyId}/api-keys/{apiKeyName}. 
-		Ticket ID: MOSIP-43700, Story ID: MOSIP-44155
-	<test name="UpdateApiKeyExpiryDate">
+		Ticket ID: MOSIP-43700, Story ID: MOSIP-44155 -->
+	<!-- <test name="UpdateApiKeyExpiryDate">
 		<parameter name="ymlFile"
 			value="pms/UpdateApiKeyExpiryDate/UpdateApiKeyExpiryDate.yml" />
 		<parameter name="pathParams" value="partnerId,policyId" />
@@ -683,11 +683,11 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.PatchWithPathParamsAndBody" />
 		</classes>
-	</test>
-	PATCH /partners/{partnerId}/policy/{policyId}/apiKey/status has 
+	</test> -->
+	<!-- PATCH /partners/{partnerId}/policy/{policyId}/apiKey/status has 
 		been deprecated and replaced by PATCH /partners/{partnerId}/policies/{policyId}/api-keys/{apiKeyName}. 
-		Ticket ID: MOSIP-44170, Story ID: MOSIP-44155
-	<test name="ActivateDeactivatePartnerApiKey">
+		Ticket ID: MOSIP-44170, Story ID: MOSIP-44155 -->
+	<!--<test name="ActivateDeactivatePartnerApiKey">
 		<parameter name="ymlFile"
 			value="pms/ActivateDeactivatePartnerApiKey/ActivateDeactivatePartnerApiKey.yml" />
 		<parameter name="pathParams" value="partnerId,policyId" />
@@ -695,7 +695,7 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.PatchWithPathParamsAndBody" />
 		</classes>
-	</test>
+	</test>-->
 	<test name="InsertDBData">
 		<parameter name="ymlFile"
 			value="pms/InsertDBData/InsertAPIKeyData.yml" />
@@ -1007,7 +1007,7 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
 	</test>
-	POST /partners/search has been deprecated from release 1.2.2.0 onwards,
+	<!-- POST /partners/search has been deprecated from release 1.2.2.0 onwards,
 	replaced by GET /admin-partners with updated test cases.
 	<test name="SearchPartner">
 		<parameter name="ymlFile"
@@ -1016,7 +1016,7 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.SimplePost" />
 		</classes>
-	</test>
+	</test> -->
 	<test name="CreateDeviceDetail">
 		<parameter name="ymlFile"
 			value="pms/device/makeAndModel/create/CreateDeviceDetail.yml" />
@@ -1611,7 +1611,7 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.DownloadRootCertificate" />
 		</classes>
 	</test>
-	POST /misps has been deprecated from release 1.3.x onwards, replaced
+	<!-- POST /misps has been deprecated from release 1.3.x onwards, replaced
 	by POST /misp-licenses with updated test cases. added in POST
 	/misp-licenses, Ticket ID: MOSIP-43118
 	<test name="CreateMispLicense">
@@ -1622,7 +1622,7 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.SimplePostForAutoGenId" />
 		</classes>
-	</test> 
+	</test>  -->
 	<test name="GenerateMISPPartnerLicense">
 		<parameter name="ymlFile"
 			value="pms/MispLicenseV3/GenerateMISPPartnerLicense/GenerateMISPPartnerLicense.yml" />
@@ -1695,7 +1695,7 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
 	</test>
-	GET /misps has been deprecated from release 1.3.x onwards, replaced
+	<!-- GET /misps has been deprecated from release 1.3.x onwards, replaced
 	by GET /misp-licenses with updated test cases. added in GET
 	/misp-licenses, Ticket ID: MOSIP-43118
 	<test name="GetMispLicense">
@@ -1705,8 +1705,8 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
-	</test> 
-	PUT /misps has been deprecated from release 1.3.x onwards, replaced
+	</test>  -->
+	<!-- PUT /misps has been deprecated from release 1.3.x onwards, replaced
 	by PUT /misp-licenses/{partnerId} with updated test cases. added in PUT
 	/misp-licenses/{partnerId}
 	Ticket ID: MOSIP-43118
@@ -1717,8 +1717,8 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.SimplePut" />
 		</classes>
-	</test>
-	GET /misps/{mispId}/licenseKey has been deprecated from release 1.3.x
+	</test> -->
+	<!-- GET /misps/{mispId}/licenseKey has been deprecated from release 1.3.x
 	onwards, replaced by GET /misp-licenses/{partnerId} with updated test
 	cases.
 	added in GET /misp-licenses/{partnerId} Ticket ID: MOSIP-43118
@@ -1729,7 +1729,7 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
-	</test> 
+	</test>  -->
 	<test name="SearchMispLicense">
 		<parameter name="ymlFile"
 			value="pms/MispLicense/SearchMispLicense/SearchMispLicense.yml" />
@@ -1796,7 +1796,7 @@
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
 	</test>
-	GET /partners has been deprecated from release 1.2.2.0 onwards,
+	<!-- GET /partners has been deprecated from release 1.2.2.0 onwards,
 	replaced
 	by GET /admin-partners with updated test cases. added in GET
 	/admin-partners
@@ -1807,7 +1807,7 @@
 			<class
 				name="io.mosip.testrig.apirig.partner.testscripts.GetWithParam" />
 		</classes>
-	</test>
+	</test> -->
 	<test name="ActivateDeactivatePartner">
 		<parameter name="ymlFile"
 			value="pms/ActivateDeactivatePartner/ActivateDeactivatePartner.yml" />


### PR DESCRIPTION
Added automated test cases for the GET /partner-api-keys/v2 endpoint to validate support for the Manual Adjudication (MA) partner type.
Changes included:

- Added positive test scenarios for retrieving MA partners with valid inputs
- Added negative test scenarios for invalid inputs (sortFieldName, SortType, partnerType, token, etc.)
- Verified error handling and response validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test suite for API key retrieval (V2) for MA partners with 18 test cases covering valid operations, authentication/authorization scenarios, and validation failures.
  * Added new tests for MA partner V3 flow including partner creation and certificate management.
  * Re-enabled previously disabled tests for API key operations and partner search endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->