### PR TITLE
[MOSIP-44943] On Passing invalid ID and invalid version API is returning positive response

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/controller/PartnerServiceController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/controller/PartnerServiceController.java
@@ -189,7 +189,8 @@ public class PartnerServiceController {
 			@PathVariable String policyId,
 			@RequestBody @Valid RequestWrapper<BioExtractorsRequestDto> request) {
 		ResponseWrapper<String> response = new ResponseWrapper<>();
-		if (!StringUtils.hasText(request.getId())) {
+		  	if (!StringUtils.hasText(request.getId())
+				|| !postPartnerBioextractorsRequestId.equalsIgnoreCase(request.getId())) {
 			throw new RequestException(
 					ValidationErrorCode.INVALID_REQUEST_ID.getErrorCode(),
 					ValidationErrorCode.INVALID_REQUEST_ID.getErrorMessage()

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/controller/PartnerServiceController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/controller/PartnerServiceController.java
@@ -85,6 +85,9 @@ public class PartnerServiceController {
 	@Value("${mosip.pms.api.id.create.partner.post}")
 	private String postCreatePartnerId;
 
+	@Value("${mosip.pms.api.id.partners.credentialtypes.request.post}")
+	private String postPartnerCredentialTypesRequestId;
+
 	@Value("${mosip.pms.api.id.partner.exists.post}")
 	private String postPartnerExistsId;
 
@@ -184,55 +187,50 @@ public class PartnerServiceController {
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getPostpartnersbioextractors())")
 	@RequestMapping(value = "/{partnerId}/policies/{policyId}/bio-extractors-request", method = RequestMethod.POST)
 	@Operation(summary = "Service to submit bio extractors request", description = "Persists bio extractor requests against an in-progress partner policy mapping request")
-	public ResponseEntity<ResponseWrapper<String>> submitBioExtractorsRequest(
+	public ResponseWrapperV2<String> submitBioExtractorsRequest(
 			@PathVariable String partnerId,
 			@PathVariable String policyId,
-			@RequestBody @Valid RequestWrapper<BioExtractorsRequestDto> request) {
-		ResponseWrapper<String> response = new ResponseWrapper<>();
-		  	if (!StringUtils.hasText(request.getId())
-				|| !postPartnerBioextractorsRequestId.equalsIgnoreCase(request.getId())) {
-			throw new RequestException(
-					ValidationErrorCode.INVALID_REQUEST_ID.getErrorCode(),
-					ValidationErrorCode.INVALID_REQUEST_ID.getErrorMessage()
-			);
-		}
-
-		if (!StringUtils.hasText(request.getVersion())
-				|| !RequestValidator.VERSION.equals(request.getVersion())) {
-			throw new RequestException(
-					ValidationErrorCode.INVALID_REQUEST_VERSION.getErrorCode(),
-					ValidationErrorCode.INVALID_REQUEST_VERSION.getErrorMessage()
-			);
+			@RequestBody @Valid RequestWrapperV2<BioExtractorsRequestDto> requestWrapper) {
+		Optional<ResponseWrapperV2<String>> validationResponse =
+				requestValidator.validate(postPartnerBioextractorsRequestId, requestWrapper);
+		if (validationResponse.isPresent()) {
+			return validationResponse.get();
 		}
 		inputValidator.validateRequestInput("partnerId", partnerId);
 		inputValidator.validateRequestInput("policyId", policyId);
-		inputValidator.validateRequestInput("partnerPolicyRequestId", request.getRequest().getPartnerPolicyRequestId());
-		request.getRequest().getExtractors().forEach(extractor -> {
+		inputValidator.validateRequestInput("partnerPolicyRequestId", requestWrapper.getRequest().getPartnerPolicyRequestId());
+		requestWrapper.getRequest().getExtractors().forEach(extractor -> {
 			inputValidator.validateRequestInput("attributeName", extractor.getAttributeName());
 			inputValidator.validateRequestInput("biometric", extractor.getBiometric());
 			inputValidator.validateRequestInput("biometricSubTypes", extractor.getBiometricSubTypes());
 			inputValidator.validateRequestInput("extractorProvider", extractor.getExtractorProvider());
 			inputValidator.validateRequestInput("extractorProviderVersion", extractor.getExtractorProviderVersion());
 		});
-		response.setResponse(partnerService.submitBioExtractorsRequest(partnerId, policyId, request.getRequest()));
-		response.setId(request.getId());
-		response.setVersion(request.getVersion());
-		return new ResponseEntity<>(response, HttpStatus.OK);
+		ResponseWrapperV2<String> response = new ResponseWrapperV2<>();
+		response.setResponse(partnerService.submitBioExtractorsRequest(partnerId, policyId, requestWrapper.getRequest()));
+		response.setId(requestWrapper.getId());
+		response.setVersion(requestWrapper.getVersion());
+		return response;
 	}
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getPostpartnersbioextractors())")
 	@RequestMapping(value = "/{partnerId}/policies/{policyId}/credential-types-request", method = RequestMethod.POST)
 	@Operation(summary = "Service to submit credential types request",
 			description = "Persists credential type request against an in-progress partner policy mapping request")
-	public ResponseEntity<ResponseWrapper<String>> submitCredentialTypesRequest(
+	public ResponseWrapperV2<String> submitCredentialTypesRequest(
 			@PathVariable String partnerId,
 			@PathVariable String policyId,
-			@RequestBody @Valid RequestWrapper<CredentialTypeRequestDto> request) {
-		ResponseWrapper<String> response = new ResponseWrapper<>();
-		response.setResponse(partnerService.submitCredentialTypesRequest(partnerId, policyId, request.getRequest()));
-		response.setId(request.getId());
-		response.setVersion(request.getVersion());
-		return new ResponseEntity<>(response, HttpStatus.OK);
+			@RequestBody @Valid RequestWrapperV2<CredentialTypeRequestDto> requestWrapper) {
+		Optional<ResponseWrapperV2<String>> validationResponse =
+				requestValidator.validate(postPartnerCredentialTypesRequestId, requestWrapper);
+		if (validationResponse.isPresent()) {
+			return validationResponse.get();
+		}
+		ResponseWrapperV2<String> response = new ResponseWrapperV2<>();
+		response.setResponse(partnerService.submitCredentialTypesRequest(partnerId, policyId, requestWrapper.getRequest()));
+		response.setId(requestWrapper.getId());
+		response.setVersion(requestWrapper.getVersion());
+		return response;
 	}
 
 	/**

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/controller/PartnerServiceController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/controller/PartnerServiceController.java
@@ -2,6 +2,7 @@ package io.mosip.pms.partner.controller;
 
 import java.io.IOException;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,11 +22,14 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.mosip.pms.common.constant.ValidationErrorCode;
+import io.mosip.pms.common.exception.RequestException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -185,6 +189,20 @@ public class PartnerServiceController {
 			@PathVariable String policyId,
 			@RequestBody @Valid RequestWrapper<BioExtractorsRequestDto> request) {
 		ResponseWrapper<String> response = new ResponseWrapper<>();
+		if (!StringUtils.hasText(request.getId())) {
+			throw new RequestException(
+					ValidationErrorCode.INVALID_REQUEST_ID.getErrorCode(),
+					ValidationErrorCode.INVALID_REQUEST_ID.getErrorMessage()
+			);
+		}
+
+		if (!StringUtils.hasText(request.getVersion())
+				|| !RequestValidator.VERSION.equals(request.getVersion())) {
+			throw new RequestException(
+					ValidationErrorCode.INVALID_REQUEST_VERSION.getErrorCode(),
+					ValidationErrorCode.INVALID_REQUEST_VERSION.getErrorMessage()
+			);
+		}
 		inputValidator.validateRequestInput("partnerId", partnerId);
 		inputValidator.validateRequestInput("policyId", policyId);
 		inputValidator.validateRequestInput("partnerPolicyRequestId", request.getRequest().getPartnerPolicyRequestId());

--- a/partner/partner-management-service/src/main/resources/bootstrap.properties
+++ b/partner/partner-management-service/src/main/resources/bootstrap.properties
@@ -181,6 +181,7 @@ mosip.pms.api.id.deactivate.misp.license.patch=mosip.pms.deactivate.misp.license
 mosip.pms.api.id.regenerate.misp.license.put=mosip.pms.regenerate.misp.license.put
 mosip.pms.api.id.partner.exists.post=mosip.pms.partner.exists.post
 mosip.pms.api.id.partners.bioextractors.request.post=mosip.pms.partners.bioextractors.request.post
+mosip.pms.api.id.partners.credentialtypes.request.post=mosip.pms.partners.credentialtypes.request.post
 mosip.pms.api.id.create.oidc.client.post=mosip.pms.create.oidc.client.post
 mosip.pms.api.id.update.oidc.client.put=mosip.pms.update.oidc.client.put
 mosip.pms.api.id.oidc.client.details.get=mosip.pms.oidc.client.details.get

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerServiceControllerTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerServiceControllerTest.java
@@ -595,7 +595,7 @@ public class PartnerServiceControllerTest {
     private RequestWrapper<PartnerRequest> createRequest() {
         RequestWrapper<PartnerRequest> request = new RequestWrapper<PartnerRequest>();
         request.setRequest(createPartnerRequest());
-        request.setId("mosip.partnermanagement.partners.create");
+        request.setId("mosip.pms.partners.bioextractors.request.post");
         request.setVersion("1.0");
         request.setRequesttime(ZonedDateTime.now(ZoneOffset.UTC).toLocalDateTime());
         request.setMetadata("{}");

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerServiceControllerTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerServiceControllerTest.java
@@ -595,7 +595,7 @@ public class PartnerServiceControllerTest {
     private RequestWrapper<PartnerRequest> createRequest() {
         RequestWrapper<PartnerRequest> request = new RequestWrapper<PartnerRequest>();
         request.setRequest(createPartnerRequest());
-        request.setId("mosip.pms.partners.bioextractors.request.post");
+        request.setId("mosip.partnermanagement.partners.create");
         request.setVersion("1.0");
         request.setRequesttime(ZonedDateTime.now(ZoneOffset.UTC).toLocalDateTime());
         request.setMetadata("{}");
@@ -688,7 +688,7 @@ public class PartnerServiceControllerTest {
     private RequestWrapper<BioExtractorsRequestDto> createSubmitBioExtractorsRequest() {
         RequestWrapper<BioExtractorsRequestDto> request = new RequestWrapper<BioExtractorsRequestDto>();
         request.setRequest(getBioExtractorsRequestInput());
-        request.setId("mosip.partnermanagement.partners.create");
+        request.setId("mosip.pms.partners.bioextractors.request.post");
         request.setVersion("1.0");
         request.setRequesttime(ZonedDateTime.now(ZoneOffset.UTC).toLocalDateTime());
         request.setMetadata("{}");

--- a/partner/pms-common/src/main/java/io/mosip/pms/common/request/dto/RequestWrapperV2.java
+++ b/partner/pms-common/src/main/java/io/mosip/pms/common/request/dto/RequestWrapperV2.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.Data;
@@ -13,6 +14,7 @@ import lombok.Data;
 public class RequestWrapperV2<T> {
     private String id;
     private String version;
+    @JsonAlias("requesttime")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime requestTime;
 

--- a/partner/pms-common/src/main/java/io/mosip/pms/common/request/dto/RequestWrapperV2.java
+++ b/partner/pms-common/src/main/java/io/mosip/pms/common/request/dto/RequestWrapperV2.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.Data;
@@ -14,7 +14,7 @@ import lombok.Data;
 public class RequestWrapperV2<T> {
     private String id;
     private String version;
-    @JsonAlias("requesttime")
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime requestTime;
 

--- a/partner/pms-common/src/main/java/io/mosip/pms/common/request/dto/RequestWrapperV2.java
+++ b/partner/pms-common/src/main/java/io/mosip/pms/common/request/dto/RequestWrapperV2.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import lombok.Data;
 public class RequestWrapperV2<T> {
     private String id;
     private String version;
-
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime requestTime;
 


### PR DESCRIPTION
[MOSIP-44943]

[MOSIP-44943]: https://mosip.atlassian.net/browse/MOSIP-44943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Submit endpoints now validate request identifiers/versions up front and return clearer error responses when validation fails.
* **New Features**
  * Submit endpoints use a standardized response format for partner submit requests.
* **Tests**
  * Tests updated to use the bioextractor request identifier to match new validation behavior.
* **Chores**
  * Added configuration key for credential-types request validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->