### PR TITLE
MOSIP-44936 When given invalid sortfield and configname in the request, error response is returning for sort field name only

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/constant/ErrorCode.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/constant/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 	INVALID_SORT_TYPE("PMS_PRT_358", "Sort type %s is not supported"),
 	ERROR_OCCURED_WHILE_SORTING("PMS_PRT_359", "Error occured while sorting"),
 	INVALID_SORT_FIELD("PMS_PRT_357", "Invalid sort field %s"),
+	INVALID_SORT_FIELD_AND_TYPE("PMS_PRT_362", "Sort field and sort type are invalid"),
 	INVALID_PAGE_NO("PMS_PRT_360", "Invalid Page No"),
 	INVALID_PAGE_SIZE("PMS_PRT_361", "Invalid page size"),
 	INVALID_VALUE("KER_PRT_390", "Invalid filter value"),

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/util/PartnerHelper.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/util/PartnerHelper.java
@@ -376,18 +376,26 @@ public class PartnerHelper {
                     ErrorCode.MISSING_PAGINATION_FOR_SORT.getErrorMessage()
             );
         }
+        boolean isInvalidSortField = sortFieldName != null && !aliasToColumnMap.containsKey(sortFieldName);
+        boolean isInvalidSortType = sortType != null
+                && !sortType.equalsIgnoreCase(PartnerConstants.ASC)
+                && !sortType.equalsIgnoreCase(PartnerConstants.DESC);
+
+        if (isInvalidSortField && isInvalidSortType) {
+            LOGGER.error("Invalid sort field name: {} and sort type: {}", sortFieldName, sortType);
+            throw new PartnerServiceException(ErrorCode.INVALID_SORT_FIELD_AND_TYPE.getErrorCode(),
+                    ErrorCode.INVALID_SORT_FIELD_AND_TYPE.getErrorMessage());
+        }
 
         // Validate sortFieldName
-        if (sortFieldName != null && !aliasToColumnMap.containsKey(sortFieldName)) {
+        if (isInvalidSortField) {
             LOGGER.error("Invalid sort field name: " + sortFieldName);
             throw new PartnerServiceException(ErrorCode.INVALID_SORT_FIELD.getErrorCode(),
                     String.format(ErrorCode.INVALID_SORT_FIELD.getErrorMessage(), sortFieldName));
         }
 
         // Validate sortType
-        if (sortType != null &&
-                !sortType.equalsIgnoreCase(PartnerConstants.ASC) &&
-                !sortType.equalsIgnoreCase(PartnerConstants.DESC)) {
+        if (isInvalidSortType) {
             LOGGER.error("Invalid sort type: " + sortType);
             throw new PartnerServiceException(ErrorCode.INVALID_SORT_TYPE.getErrorCode(),
                     String.format(ErrorCode.INVALID_SORT_TYPE.getErrorMessage(), sortType));


### PR DESCRIPTION
[MOSIP-44936]

[MOSIP-44936]: https://mosip.atlassian.net/browse/MOSIP-44936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for sort parameter validation with more specific error messages when both sort field and sort type inputs are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->