### PR TITLE
MOSIP-44970 Fixed Inconsistent validation for biomodality field for alphabets accepted but special characters the error

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
@@ -755,7 +755,6 @@ public class PartnerManagementController {
 		inputValidator.validateRequestInput("configName", request.getConfigName());
 		inputValidator.validateRequestInput("bioextractorProviderName", request.getBioextractorProviderName());
 		inputValidator.validateRequestInput("bioextractorProviderVersion", request.getBioextractorProviderVersion());
-		inputValidator.validateRequestInput("bioModality", request.getBioModality());
 		return partnerManagementService.createBioextractorConfiguration(request);
 	}
 
@@ -809,7 +808,7 @@ public class PartnerManagementController {
 		inputValidator.validateRequestInput("configName", configName);
 		inputValidator.validateRequestInput("bioextractorProviderName", bioextractorProviderName);
 		inputValidator.validateRequestInput("bioextractorProviderVersion", bioextractorProviderVersion);
-		inputValidator.validateRequestInput("bioModality", bioModality);
+
 
 		BioextractorConfigurationFilterDto filterDto = new BioextractorConfigurationFilterDto();
 		if (configName != null) filterDto.setConfigName(configName.toLowerCase());

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -2054,9 +2054,7 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 
 		String bioModality = bioModalityRaw.trim().toLowerCase();
 		if (!modalityToAttribute.containsKey(bioModality)) {
-			String validModalities = modalityToAttribute.keySet().stream()
-					.reduce((a, b) -> a + ", " + b)
-					.orElse("");
+            String validModalities = String.join(", ", modalityToAttribute.keySet());
 			throw new PartnerServiceException(
 					io.mosip.pms.partner.constant.ErrorCode.INVALID_INPUT_FORMAT.getErrorCode(),
 					String.format(io.mosip.pms.partner.constant.ErrorCode.INVALID_INPUT_FORMAT.getErrorMessage(),


### PR DESCRIPTION
[MOSIP-44970]

[MOSIP-44970]: https://mosip.atlassian.net/browse/MOSIP-44970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation requirements for bioextractor configuration inputs.
  * Streamlined validation constraints for optional filter parameters.

* **Refactor**
  * Optimized internal message formatting for validation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->