### PR TITLE
MOSIP-44953 system returns the error message as Partner api key does not exist

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/constant/ErrorCode.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/constant/ErrorCode.java
@@ -10,7 +10,7 @@ public enum ErrorCode {
 	INVALID_STATUS_CODE_ACTIVE_DEACTIVE("PMS_PM_058", "Status should be either Active or De-Active"),
 	NEW_POLICY_ID_NOT_EXIST("PMS_PMP_010","Policy does not belong to the Policy Group of the Partner Manger"),
 	NO_PARTNER_API_KEY_REQUEST_EXCEPTION("PMS_PMP_015","No Partner api key requests for the Policy Group"),
-	PARTNER_API_DOES_NOT_EXIST_EXCEPTION("PMS_PMP_007","Partner api key does not exist"),
+	PARTNER_API_DOES_NOT_EXIST_EXCEPTION("PMS_PMP_007","Mapping key does not exist"),
 	PARTNER_API_DOES_NOT_BELONGS_TO_THE_POLICYGROUP_OF_PARTNERMANAGER_EXCEPTION(
 			"PMS_PMP_009","Partner api key does not belong to the Policy Group of the Partner Manger"),
 	PARTNER_API_KEY_DOES_NOT_EXIST_EXCEPTION("PMS_PMP_011","Partner api key does not exist"),


### PR DESCRIPTION
[MOSIP-44953]

[MOSIP-44953]: https://mosip.atlassian.net/browse/MOSIP-44953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error messages to provide more accurate and specific descriptions when API key mapping issues occur within partner management operations.

* **New Features**
  * Introduced new error code to appropriately handle scenarios where no partner API key requests exist for a designated policy group, improving system error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->