### PR TITLE
MOSIP-44959 When passing a page number with up to 9 digits, the API/system returns a proper response.

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
@@ -771,18 +771,36 @@ public class PartnerManagementController {
 	public ResponseWrapperV2<PageResponseV2Dto<BioextractorConfigurationDetailDto>> getBioextractorConfigurations(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType,
-			@RequestParam(value = "pageNo", required = false) Integer pageNo,
+			@RequestParam(value = "pageNo", required = false) String pageNo,
 			@RequestParam(value = "pageSize", required = false) Integer pageSize,
 			@RequestParam(value = "configName", required = false) String configName,
 			@RequestParam(value = "bioextractorProviderName", required = false) String bioextractorProviderName,
 			@RequestParam(value = "bioextractorProviderVersion", required = false) String bioextractorProviderVersion,
 			@RequestParam(value = "bioModality", required = false) String bioModality
 	) {
+		Integer parsedPageNo = parsePageNo(pageNo);
 		BioextractorConfigurationFilterDto filterDto = populateBioextractorConfigurationFilterDto(
-				sortFieldName, sortType, pageNo, pageSize, configName, bioextractorProviderName,
+				sortFieldName, sortType, parsedPageNo, pageSize, configName, bioextractorProviderName,
 				bioextractorProviderVersion, bioModality);
 		return partnerManagementService.getBioextractorConfigurations(
-				sortFieldName, sortType, pageNo, pageSize, filterDto);
+				sortFieldName, sortType, parsedPageNo, pageSize, filterDto);
+	}
+
+	private Integer parsePageNo(String pageNo) {
+		if (pageNo == null) {
+			return null;
+		}
+		try {
+			long parsedPageNo = Long.parseLong(pageNo);
+			if (parsedPageNo > Integer.MAX_VALUE || parsedPageNo < Integer.MIN_VALUE) {
+				throw new PartnerServiceException(ErrorCode.INVALID_PAGE_NO.getErrorCode(),
+						ErrorCode.INVALID_PAGE_NO.getErrorMessage());
+			}
+			return (int) parsedPageNo;
+		} catch (NumberFormatException ex) {
+			throw new PartnerServiceException(ErrorCode.INVALID_PAGE_NO.getErrorCode(),
+					ErrorCode.INVALID_PAGE_NO.getErrorMessage());
+		}
 	}
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getGetbioextractorconfigurationdetails())")

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerManagementControllerTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerManagementControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -898,6 +899,21 @@ public class PartnerManagementControllerTest {
 		verify(partnerManagementService, times(1))
 				.getBioextractorConfigurations(any(), any(), any(), any(), any(BioextractorConfigurationFilterDto.class));
 	}
+
+	@Test
+	@WithMockUser(roles = {"PARTNER_ADMIN"})
+	public void getBioextractorConfigurationsWithVeryLargePageNoReturnsBadRequest() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.get("/bio-extractor-configurations")
+						.param("pageNo", "4567890908909")
+						.param("pageSize", "8")
+						.contentType(MediaType.APPLICATION_JSON_VALUE))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
+				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
+		verify(partnerManagementService, never())
+				.getBioextractorConfigurations(any(), any(), any(), any(), any(BioextractorConfigurationFilterDto.class));
+	}
+
 
 	@Test
 	@WithMockUser(roles = {"PARTNER_ADMIN"})


### PR DESCRIPTION
[MOSIP-44959]

[MOSIP-44959]: https://mosip.atlassian.net/browse/MOSIP-44959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation for the page number parameter in the bio-extractor-configurations endpoint. Invalid or out-of-range page numbers now return a descriptive error message with validation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->