### PR TITLE
MOSIP-44959 When passing a page number with up to 9 digits, the API/system returns a proper response.

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/device/controller/DeviceDetailController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/device/controller/DeviceDetailController.java
@@ -303,7 +303,7 @@ public class DeviceDetailController {
 	public ResponseWrapperV2<PageResponseV2Dto<DeviceDetailSummaryDto>> getAllDeviceDetails(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType,
-			@RequestParam(value = "pageNo", defaultValue = "0") Integer pageNo,
+			@RequestParam(value = "pageNo", defaultValue = "0") String pageNo,
 			@RequestParam(value = "pageSize", defaultValue = "8") Integer pageSize,
 			@RequestParam(value = "partnerId", required = false) String partnerId,
 			@RequestParam(value = "orgName", required = false) String orgName,
@@ -364,6 +364,7 @@ public class DeviceDetailController {
 		if (deviceId != null) {
 			filterDto.setDeviceId(deviceId.toLowerCase());
 		}
-		return deviceDetaillService.getAllDeviceDetails(sortFieldName, sortType, pageNo, pageSize, filterDto);
+		Integer normalizedPageNo = partnerHelper.parsePageNo(pageNo);
+		return deviceDetaillService.getAllDeviceDetails(sortFieldName, sortType, normalizedPageNo, pageSize, filterDto);
 	}
 }

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/device/controller/FTPChipDetailController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/device/controller/FTPChipDetailController.java
@@ -327,7 +327,7 @@ public class FTPChipDetailController {
 	ResponseWrapperV2<PageResponseV2Dto<FtmDetailSummaryDto>> getPartnersFtmChipDetails(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType,
-			@RequestParam(value = "pageNo", defaultValue = "0") Integer pageNo,
+			@RequestParam(value = "pageNo", defaultValue = "0") String pageNo,
 			@RequestParam(value = "pageSize", defaultValue = "8") Integer pageSize,
 			@RequestParam(value = "partnerId", required = false) String partnerId,
 			@RequestParam(value = "orgName", required = false) String orgName,
@@ -368,7 +368,8 @@ public class FTPChipDetailController {
 		if (status != null) {
 			filterDto.setStatus(status);
 		}
-		return ftpChipDetaillService.getPartnersFtmChipDetails(sortFieldName, sortType, pageNo, pageSize, filterDto);
+		Integer normalizedPageNo = partnerHelper.parsePageNo(pageNo);
+		return ftpChipDetaillService.getPartnersFtmChipDetails(sortFieldName, sortType, normalizedPageNo, pageSize, filterDto);
 	}
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getGetftmchipdetails())")

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/device/controller/SecureBiometricInterfaceController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/device/controller/SecureBiometricInterfaceController.java
@@ -338,7 +338,7 @@ public class SecureBiometricInterfaceController {
 	ResponseWrapperV2<PageResponseV2Dto<SbiSummaryDto>> getAllSbiDetails(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType,
-			@RequestParam(value = "pageNo", required = false) Integer pageNo,
+			@RequestParam(value = "pageNo", required = false) String pageNo,
 			@RequestParam(value = "pageSize", required = false) Integer pageSize,
 			@RequestParam(value = "partnerId", required = false) String partnerId,
 			@RequestParam(value = "orgName", required = false) String orgName,
@@ -391,6 +391,7 @@ public class SecureBiometricInterfaceController {
 		if (expiryPeriod != null) {
 			filterDto.setExpiryPeriod(expiryPeriod);
 		}
-		return secureBiometricInterface.getAllSbiDetails(sortFieldName, sortType, pageNo, pageSize, filterDto);
+		Integer normalizedPageNo = partnerHelper.parsePageNo(pageNo);
+		return secureBiometricInterface.getAllSbiDetails(sortFieldName, sortType, normalizedPageNo, pageSize, filterDto);
 	}
 }

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/oauth/client/controller/ClientManagementController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/oauth/client/controller/ClientManagementController.java
@@ -168,7 +168,7 @@ public class ClientManagementController {
 	public ResponseWrapperV2<PageResponseV2Dto<ClientSummaryDto>> getPartnersClients(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType,
-			@RequestParam(value = "pageNo", required = false) Integer pageNo,
+			@RequestParam(value = "pageNo", required = false) String pageNo,
 			@RequestParam(value = "pageSize", required = false) Integer pageSize,
 			@RequestParam(value = "partnerId", required = false) String partnerId,
 			@RequestParam(value = "orgName", required = false) String orgName,
@@ -182,9 +182,10 @@ public class ClientManagementController {
 			)
 			@RequestParam(value = "status", required = false) String status
 	) {
-		ClientFilterDto filterDto = populateClientFilterDto(sortFieldName, sortType, pageNo, pageSize,
+		Integer normalizedPageNo = partnerHelper.parsePageNo(pageNo);
+		ClientFilterDto filterDto = populateClientFilterDto(sortFieldName, sortType, normalizedPageNo, pageSize,
 				partnerId, orgName, policyGroupName, policyName, clientName, status);
-		return clientManagementService.getPartnersClientsV2(sortFieldName, sortType, pageNo, pageSize, filterDto);
+		return clientManagementService.getPartnersClientsV2(sortFieldName, sortType, normalizedPageNo, pageSize, filterDto);
 	}
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getGetoauthpartnersclients())")
@@ -197,7 +198,7 @@ public class ClientManagementController {
 	public ResponseWrapperV2<PageResponseV2Dto<ClientSummaryDto>> getPartnersClientsV2(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType,
-			@RequestParam(value = "pageNo", required = false) Integer pageNo,
+			@RequestParam(value = "pageNo", required = false) String pageNo,
 			@RequestParam(value = "pageSize", required = false) Integer pageSize,
 			@RequestParam(value = "partnerId", required = false) String partnerId,
 			@RequestParam(value = "orgName", required = false) String orgName,
@@ -211,9 +212,10 @@ public class ClientManagementController {
 			)
 			@RequestParam(value = "status", required = false) String status
 	) {
-		ClientFilterDto filterDto = populateClientFilterDto(sortFieldName, sortType, pageNo, pageSize,
+		Integer normalizedPageNo = partnerHelper.parsePageNo(pageNo);
+		ClientFilterDto filterDto = populateClientFilterDto(sortFieldName, sortType, normalizedPageNo, pageSize,
 				partnerId, orgName, policyGroupName, policyName, clientName, status);
-		return clientManagementService.getPartnersClientsV2(sortFieldName, sortType, pageNo, pageSize, filterDto);
+		return clientManagementService.getPartnersClientsV2(sortFieldName, sortType, normalizedPageNo, pageSize, filterDto);
 	}
 
 	private ClientFilterDto populateClientFilterDto(String sortFieldName, String sortType, Integer pageNo, Integer pageSize, String partnerId,

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/controller/NotificationsController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/controller/NotificationsController.java
@@ -12,6 +12,7 @@ import io.mosip.pms.common.validator.InputValidator;
 import io.mosip.pms.partner.dto.NotificationsFilterDto;
 import io.mosip.pms.common.dto.NotificationsResponseDto;
 import io.mosip.pms.partner.service.NotificationsService;
+import io.mosip.pms.partner.util.PartnerHelper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -43,6 +44,9 @@ public class NotificationsController {
     @Autowired
 	private InputValidator inputValidator;
 
+    @Autowired
+    private PartnerHelper partnerHelper;
+
     @PreAuthorize("hasAnyRole(@authorizedRoles.getGetnotifications())")
     @GetMapping(value = "/notifications")
     @Operation(summary = "This endpoint retrieves a list of all notifications.",
@@ -65,7 +69,7 @@ public class NotificationsController {
                     schema = @Schema(allowableValues = {"root", "intermediate", "partner", "weekly", "sbi", "ftm-chip", "apikey", "misp"})
             )
             @RequestParam(value = "notificationType", required = false) String notificationType,
-            @RequestParam(value = "pageNo", defaultValue = "0") Integer pageNo,
+            @RequestParam(value = "pageNo", defaultValue = "0") String pageNo,
             @RequestParam(value = "pageSize", defaultValue = "4") Integer pageSize,
             @RequestParam(value = "certificateId", required = false) String certificateId,
             @RequestParam(value = "expiryDate", required = false)
@@ -165,7 +169,10 @@ public class NotificationsController {
         if (mispPartnerId != null) {
             filterDto.setMispPartnerId(mispPartnerId);
         }
-        return notificationsService.getNotifications(pageNo, pageSize, filterDto);
+        return notificationsService.getNotifications(
+                partnerHelper.parsePageNo(pageNo),
+                pageSize,
+                filterDto);
     }
 
     @PreAuthorize("hasAnyRole(@authorizedRoles.getPatchdismissnotification())")

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/controller/PartnerManagementController.java
@@ -337,7 +337,7 @@ public class PartnerManagementController {
 	public ResponseWrapperV2<PageResponseV2Dto<PartnerSummaryDto>> getAdminPartners(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType, // e.g., ASC or DESC
-			@RequestParam(value = "pageNo", defaultValue = "0") Integer pageNo,
+			@RequestParam(value = "pageNo", defaultValue = "0") String pageNo,
 			@RequestParam(value = "pageSize", defaultValue = "8") Integer pageSize,
 			@RequestParam(value = "partnerId", required = false) String partnerId,
 			@RequestParam(value = "partnerType", required = false) String partnerType,
@@ -392,7 +392,9 @@ public class PartnerManagementController {
 		if (status != null) {
 			partnerFilterDto.setStatus(status);
 		}
-		return partnerManagementService.getAdminPartners(sortFieldName, sortType, pageNo, pageSize, partnerFilterDto);
+		return partnerManagementService.getAdminPartners(sortFieldName, sortType,
+				partnerHelper.parsePageNo(pageNo),
+				pageSize, partnerFilterDto);
 	}
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getGetallpartnerpolicymappingrequests())")
@@ -407,7 +409,7 @@ public class PartnerManagementController {
 	public ResponseWrapperV2<PageResponseV2Dto<PartnerPolicyRequestSummaryDto>> getAllPartnerPolicyRequests(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType,
-			@RequestParam(value = "pageNo", required = false) Integer pageNo,
+			@RequestParam(value = "pageNo", required = false) String pageNo,
 			@RequestParam(value = "pageSize", required = false) Integer pageSize,
 			@RequestParam(value = "partnerId", required = false) String partnerId,
 			@Parameter(
@@ -476,7 +478,9 @@ public class PartnerManagementController {
 		if (partnerType != null) {
 			filterDto.setPartnerType(partnerType.toLowerCase());
 		}
-		return partnerManagementService.getAllPartnerPolicyRequests(sortFieldName, sortType, pageNo, pageSize, filterDto);
+		return partnerManagementService.getAllPartnerPolicyRequests(sortFieldName, sortType,
+				partnerHelper.parsePageNo(pageNo),
+				pageSize, filterDto);
 	}
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getGetpartnersbioextractors())")
@@ -522,7 +526,7 @@ public class PartnerManagementController {
 	public ResponseWrapperV2<PageResponseV2Dto<ApiKeyRequestSummaryDto>> getAllApiKeyRequests(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType,
-			@RequestParam(value = "pageNo",  required = false) Integer pageNo,
+			@RequestParam(value = "pageNo",  required = false) String pageNo,
 			@RequestParam(value = "pageSize",  required = false) Integer pageSize,
 			@RequestParam(value = "partnerId", required = false) String partnerId,
 			@RequestParam(value = "apiKeyLabel", required = false) String apiKeyLabel,
@@ -545,7 +549,9 @@ public class PartnerManagementController {
 		inputValidator.validateRequestInput("policyName", policyName);
 		inputValidator.validateRequestInput("policyGroupName", policyGroupName);
 		ApiKeyFilterDto filterDto = populateApiKeyFilterDto(partnerId, apiKeyLabel, orgName, status, policyName, policyGroupName, null, null);
-		return partnerManagementService.getAllApiKeyRequests(sortFieldName, sortType, pageNo, pageSize, filterDto);
+		return partnerManagementService.getAllApiKeyRequests(sortFieldName, sortType,
+				partnerHelper.parsePageNo(pageNo),
+				pageSize, filterDto);
 	}
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getGetpartnersapikeyrequests())")
@@ -560,7 +566,7 @@ public class PartnerManagementController {
 	public ResponseWrapperV2<PageResponseV2Dto<ApiKeyRequestSummaryV2Dto>> getAllApiKeyRequestsV2(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType,
-			@RequestParam(value = "pageNo",  required = false) Integer pageNo,
+			@RequestParam(value = "pageNo",  required = false) String pageNo,
 			@RequestParam(value = "pageSize",  required = false) Integer pageSize,
 			@RequestParam(value = "partnerId", required = false) String partnerId,
 			@RequestParam(value = "apiKeyLabel", required = false) String apiKeyLabel,
@@ -590,7 +596,9 @@ public class PartnerManagementController {
 		inputValidator.validateRequestInput("policyGroupName", policyGroupName);
 		inputValidator.validateRequestInput("partnerType", partnerType);
 		ApiKeyFilterDto filterDto = populateApiKeyFilterDto(partnerId, apiKeyLabel, orgName, status, policyName, policyGroupName, partnerType, expiryPeriod);
-		return partnerManagementService.getAllApiKeyRequestsV2(sortFieldName, sortType, pageNo, pageSize, filterDto);
+		return partnerManagementService.getAllApiKeyRequestsV2(sortFieldName, sortType,
+				partnerHelper.parsePageNo(pageNo),
+				pageSize, filterDto);
 	}
 
 	private ApiKeyFilterDto populateApiKeyFilterDto(String partnerId, String apiKeyLabel, String orgName, String status,
@@ -620,7 +628,7 @@ public class PartnerManagementController {
 	public ResponseWrapperV2<PageResponseV2Dto<TrustCertificateSummaryDto>> getTrustCertificates(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType, // e.g., ASC or DESC
-			@RequestParam(value = "pageNo", defaultValue = "0") Integer pageNo,
+			@RequestParam(value = "pageNo", defaultValue = "0") String pageNo,
 			@RequestParam(value = "pageSize", defaultValue = "8") Integer pageSize,
 			@Parameter(
 					description = "Type of CA certificate",
@@ -668,7 +676,9 @@ public class PartnerManagementController {
 		if (expiryPeriod != null){
 			filterDto.setExpiryPeriod(expiryPeriod);
 		}
-		return partnerManagementService.getTrustCertificates(sortFieldName, sortType, pageNo, pageSize, filterDto);
+		return partnerManagementService.getTrustCertificates(sortFieldName, sortType,
+				partnerHelper.parsePageNo(pageNo),
+				pageSize, filterDto);
 	}
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getGetdownloadtrustcertificates())")
@@ -776,18 +786,19 @@ public class PartnerManagementController {
 	public ResponseWrapperV2<PageResponseV2Dto<BioextractorConfigurationDetailDto>> getBioextractorConfigurations(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType,
-			@RequestParam(value = "pageNo", required = false) Integer pageNo,
+			@RequestParam(value = "pageNo", required = false) String pageNo,
 			@RequestParam(value = "pageSize", required = false) Integer pageSize,
 			@RequestParam(value = "configName", required = false) String configName,
 			@RequestParam(value = "bioextractorProviderName", required = false) String bioextractorProviderName,
 			@RequestParam(value = "bioextractorProviderVersion", required = false) String bioextractorProviderVersion,
 			@RequestParam(value = "bioModality", required = false) String bioModality
 	) {
+		Integer normalizedPageNo = partnerHelper.parsePageNo(pageNo);
 		BioextractorConfigurationFilterDto filterDto = populateBioextractorConfigurationFilterDto(
-				sortFieldName, sortType, pageNo, pageSize, configName, bioextractorProviderName,
+				sortFieldName, sortType, normalizedPageNo, pageSize, configName, bioextractorProviderName,
 				bioextractorProviderVersion, bioModality);
 		return partnerManagementService.getBioextractorConfigurations(
-				sortFieldName, sortType, pageNo, pageSize, filterDto);
+				sortFieldName, sortType, normalizedPageNo, pageSize, filterDto);
 	}
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getGetbioextractorconfigurationdetails())")

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/misp/controller/MISPLicenseController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/misp/controller/MISPLicenseController.java
@@ -38,6 +38,7 @@ import io.mosip.pms.common.request.dto.RequestWrapper;
 import io.mosip.pms.common.response.dto.ResponseWrapper;
 import io.mosip.pms.device.response.dto.FilterResponseCodeDto;
 import io.mosip.pms.partner.misp.dto.MISPLicenseRequestDto;
+import io.mosip.pms.partner.util.PartnerHelper;
 import io.mosip.pms.partner.misp.dto.MISPLicenseResponseDto;
 import io.mosip.pms.partner.misp.dto.MISPLicenseUpdateRequestDto;
 import io.mosip.pms.partner.misp.dto.MISPLicenseSummaryDto;
@@ -64,6 +65,9 @@ public class MISPLicenseController {
 
 	@Autowired
 	RequestValidator requestValidator;
+
+	@Autowired
+	private PartnerHelper partnerHelper;
 
 	@Value("${mosip.pms.api.id.misp.generate.license.post}")
 	private String postGenerateMISPApiId;
@@ -148,7 +152,7 @@ public class MISPLicenseController {
 	public ResponseWrapperV2<PageResponseV2Dto<MISPLicenseSummaryDto>> getAllMISPLicenses(
 			@RequestParam(value = "sortFieldName", required = false) String sortFieldName,
 			@RequestParam(value = "sortType", required = false) String sortType,
-			@RequestParam(value = "pageNo", defaultValue = "0") Integer pageNo,
+			@RequestParam(value = "pageNo", defaultValue = "0") String pageNo,
 			@RequestParam(value = "pageSize", defaultValue = "8") Integer pageSize,
 			@RequestParam(value = "partnerId", required = false) String partnerId,
 			@RequestParam(value = "orgName", required = false) String orgName,
@@ -196,7 +200,9 @@ public class MISPLicenseController {
 		if (expiryPeriod != null) {
 			filterDto.setExpiryPeriod(expiryPeriod);
 		}
-		return infraProviderService.getAllMISPLicenses(sortFieldName, sortType, pageNo, pageSize, filterDto);
+		return infraProviderService.getAllMISPLicenses(sortFieldName, sortType,
+				partnerHelper.parsePageNo(pageNo),
+				pageSize, filterDto);
 	}
 
 	@PostMapping("/misp-licenses")

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/util/PartnerHelper.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/util/PartnerHelper.java
@@ -413,6 +413,24 @@ public class PartnerHelper {
                 && Objects.isNull(pageNo) && Objects.isNull(pageSize);
     }
 
+    public Integer parsePageNo(String pageNo) {
+        if (pageNo == null) {
+            return null;
+        }
+        try {
+            int parsedPageNo = Integer.parseInt(pageNo);
+            if (parsedPageNo < 0) {
+                throw new PartnerServiceException(ErrorCode.INVALID_PAGE_NO.getErrorCode(),
+                        ErrorCode.INVALID_PAGE_NO.getErrorMessage());
+            }
+            return parsedPageNo;
+        } catch (NumberFormatException ex) {
+            throw new PartnerServiceException(ErrorCode.INVALID_PAGE_NO.getErrorCode(),
+                    ErrorCode.INVALID_PAGE_NO.getErrorMessage());
+        }
+    }
+
+
     public void checkIfPartnerIsNotActive(Partner partner) {
         if (!partner.getIsActive()) {
             LOGGER.error("Partner is not Active with id {}", partner.getId());

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/misp/controller/MISPLicenseControllerTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/misp/controller/MISPLicenseControllerTest.java
@@ -2,6 +2,7 @@ package io.mosip.pms.test.misp.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
@@ -69,7 +70,7 @@ public class MISPLicenseControllerTest {
 
 	@MockBean
 	private InfraProviderServiceImpl infraProvidertService;
-	
+
 	@Autowired
 	private ObjectMapper objectMapper;
 
@@ -291,6 +292,28 @@ public class MISPLicenseControllerTest {
 						.param("pageNo", String.valueOf(pageNo))
 						.param("pageSize", String.valueOf(pageSize)))
 				.andExpect(MockMvcResultMatchers.status().isOk());
+	}
+
+	@Test
+	@WithMockUser(roles = {"PARTNER_ADMIN"})
+	public void getMispLicensesWithVeryLargePageNoReturnsValidationError() throws Exception {
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/misp-licenses")
+						.param("pageNo", "4567890908909")
+						.param("pageSize", "8")
+						.contentType(MediaType.APPLICATION_JSON_VALUE))
+
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
+				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
+
+		verify(infraProvidertService, never())
+				.getAllMISPLicenses(
+						any(),
+						any(),
+						any(),
+						any(),
+						any(MISPFilterDto.class));
 	}
 
 	@Test

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/NotificationsControllerTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/NotificationsControllerTest.java
@@ -30,6 +30,11 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import java.time.LocalDateTime;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
@@ -140,6 +145,23 @@ public class NotificationsControllerTest {
 
         mockMvc.perform(MockMvcRequestBuilders.patch("/notifications/12345").contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(requestWrapper))).andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = {"PARTNER_ADMIN"})
+    public void getNotificationsWithVeryLargePageNoReturnsValidationError() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/notifications")
+                        .param("pageNo", "4567890908909")
+                        .param("pageSize", "4")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
+                .andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
+
+        verify(notificationsService, never())
+                .getNotifications(anyInt(), anyInt(), any(NotificationsFilterDto.class));
     }
 
     @Test

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerManagementControllerTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerManagementControllerTest.java
@@ -127,6 +127,9 @@ public class PartnerManagementControllerTest {
 	@MockBean
 	private InfraServiceProviderService infraProviderService;
 
+    @MockBean
+    private NotificationsService notificationsService;
+
 	@Test
 	@WithMockUser(roles = {"PARTNERMANAGER"})
 	public void partnerApiKeyToPolicyMappingsTest() throws Exception {
@@ -916,6 +919,9 @@ public class PartnerManagementControllerTest {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
 				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
+
+        verify(notificationsService, never())
+                .getNotifications(anyInt(), anyInt(), any(NotificationsFilterDto.class));
 	}
 
 	@Test

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerManagementControllerTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerManagementControllerTest.java
@@ -19,7 +19,6 @@ import io.mosip.pms.common.dto.TrustCertificateSummaryDto;
 import io.mosip.pms.common.request.dto.RequestWrapperV2;
 import io.mosip.pms.common.response.dto.ResponseWrapperV2;
 import io.mosip.pms.common.util.RequestValidator;
-import io.mosip.pms.partner.dto.NotificationsFilterDto;
 import io.mosip.pms.partner.manager.controller.PartnerManagementController;
 import io.mosip.pms.partner.manager.dto.*;
 import io.mosip.pms.partner.manager.service.impl.PartnerManagementServiceImpl;
@@ -65,9 +64,6 @@ import io.mosip.pms.device.util.AuditUtil;
 import io.mosip.pms.partner.manager.constant.PartnerManageEnum;
 import io.mosip.pms.partner.manager.service.PartnerManagerService;
 import io.mosip.pms.partner.request.dto.APIkeyStatusUpdateRequestDto;
-import io.mosip.pms.oauth.client.service.ClientManagementService;
-import io.mosip.pms.partner.misp.service.InfraServiceProviderService;
-import io.mosip.pms.partner.service.NotificationsService;
 
 
 @RunWith(SpringRunner.class)
@@ -120,15 +116,6 @@ public class PartnerManagementControllerTest {
 	public void setUp() {
 		Mockito.doNothing().when(audit).setAuditRequestDto(Mockito.any(PartnerManageEnum.class));
 	}
-
-	@MockBean
-	private ClientManagementService clientManagementService;
-
-	@MockBean
-	private InfraServiceProviderService infraProviderService;
-
-    @MockBean
-    private NotificationsService notificationsService;
 
 	@Test
 	@WithMockUser(roles = {"PARTNERMANAGER"})
@@ -888,57 +875,6 @@ public class PartnerManagementControllerTest {
 
 		verify(partnerManagementService, never())
 				.getBioextractorConfigurations(any(), any(), any(), any(), any());
-	}
-
-	@Test
-	@WithMockUser(roles = {"PARTNER_ADMIN"})
-	public void getOidcClientsWithVeryLargePageNoReturnsValidationError() throws Exception {
-
-		mockMvc.perform(MockMvcRequestBuilders.get("/oidc-clients")
-						.param("pageNo", "4567890908909")
-						.param("pageSize", "8")
-						.contentType(MediaType.APPLICATION_JSON_VALUE))
-
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
-				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
-
-		verify(clientManagementService, never())
-				.getPartnersClientsV2(any(), any(), any(), any(), any());
-	}
-
-	@Test
-	@WithMockUser(roles = {"PARTNER_ADMIN"})
-	public void getNotificationsWithVeryLargePageNoReturnsValidationError() throws Exception {
-
-		mockMvc.perform(MockMvcRequestBuilders.get("/notifications")
-						.param("pageNo", "4567890908909")
-						.param("pageSize", "4")
-						.contentType(MediaType.APPLICATION_JSON_VALUE))
-
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
-				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
-
-        verify(notificationsService, never())
-                .getNotifications(anyInt(), anyInt(), any(NotificationsFilterDto.class));
-	}
-
-	@Test
-	@WithMockUser(roles = {"PARTNER_ADMIN"})
-	public void getMispLicensesWithVeryLargePageNoReturnsValidationError() throws Exception {
-
-		mockMvc.perform(MockMvcRequestBuilders.get("/misp-licenses")
-						.param("pageNo", "4567890908909")
-						.param("pageSize", "8")
-						.contentType(MediaType.APPLICATION_JSON_VALUE))
-
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
-				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
-
-		verify(infraProviderService, never())
-				.getAllMISPLicenses(any(), any(), any(), any(), any());
 	}
 
 	@Test

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerManagementControllerTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerManagementControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -18,6 +19,7 @@ import io.mosip.pms.common.dto.TrustCertificateSummaryDto;
 import io.mosip.pms.common.request.dto.RequestWrapperV2;
 import io.mosip.pms.common.response.dto.ResponseWrapperV2;
 import io.mosip.pms.common.util.RequestValidator;
+import io.mosip.pms.partner.dto.NotificationsFilterDto;
 import io.mosip.pms.partner.manager.controller.PartnerManagementController;
 import io.mosip.pms.partner.manager.dto.*;
 import io.mosip.pms.partner.manager.service.impl.PartnerManagementServiceImpl;
@@ -63,6 +65,9 @@ import io.mosip.pms.device.util.AuditUtil;
 import io.mosip.pms.partner.manager.constant.PartnerManageEnum;
 import io.mosip.pms.partner.manager.service.PartnerManagerService;
 import io.mosip.pms.partner.request.dto.APIkeyStatusUpdateRequestDto;
+import io.mosip.pms.oauth.client.service.ClientManagementService;
+import io.mosip.pms.partner.misp.service.InfraServiceProviderService;
+import io.mosip.pms.partner.service.NotificationsService;
 
 
 @RunWith(SpringRunner.class)
@@ -115,7 +120,13 @@ public class PartnerManagementControllerTest {
 	public void setUp() {
 		Mockito.doNothing().when(audit).setAuditRequestDto(Mockito.any(PartnerManageEnum.class));
 	}
-	
+
+	@MockBean
+	private ClientManagementService clientManagementService;
+
+	@MockBean
+	private InfraServiceProviderService infraProviderService;
+
 	@Test
 	@WithMockUser(roles = {"PARTNERMANAGER"})
 	public void partnerApiKeyToPolicyMappingsTest() throws Exception {
@@ -375,7 +386,7 @@ public class PartnerManagementControllerTest {
 	public void getAllPartnersTest() throws Exception {
 		String sortFieldName = "createdDateTime";
 		String sortType = "desc";
-		Integer pageNo = 0;
+		String pageNo = "0";
 		Integer pageSize = 8;
 		PartnerFilterDto partnerFilterDto = new PartnerFilterDto();
 		partnerFilterDto.setPartnerId("abc");
@@ -387,7 +398,7 @@ public class PartnerManagementControllerTest {
 		partnerFilterDto.setIsActive(false);
 		ResponseWrapperV2<PageResponseV2Dto<PartnerSummaryDto>> responseWrapper = new ResponseWrapperV2<>();
 
-		Mockito.when(partnerManagementService.getAdminPartners(sortFieldName, sortType, pageNo, pageSize, partnerFilterDto))
+		Mockito.when(partnerManagementService.getAdminPartners(sortFieldName, sortType, 0, pageSize, partnerFilterDto))
 				.thenReturn(responseWrapper);
 		mockMvc.perform(MockMvcRequestBuilders.get("/admin-partners?sortFieldName=createdDateTime&sortType=desc&pageSize=8&pageNo=0&" +
 						"partnerId=abc&partnerType=Auth_Partner&orgName=ABC&emailAddress=abc&certificateUploadStatus=not_uploaded&policyGroupName=default&isActive=false"))
@@ -792,6 +803,139 @@ public class PartnerManagementControllerTest {
 	}
 
 	@Test
+	@WithMockUser(roles = {"PARTNER_ADMIN"})
+	public void getAllPartnersWithVeryLargePageNoReturnsValidationError() throws Exception {
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin-partners")
+						.param("pageNo", "4567890908909")
+						.param("pageSize", "8")
+						.contentType(MediaType.APPLICATION_JSON_VALUE))
+
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
+				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
+
+		verify(partnerManagementService, never())
+				.getAdminPartners(any(), any(), any(), any(), any(PartnerFilterDto.class));
+	}
+
+	@Test
+	@WithMockUser(roles = {"PARTNER_ADMIN"})
+	public void getAllPartnerPolicyRequestsWithVeryLargePageNoReturnsValidationError() throws Exception {
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/partner-policy-requests")
+						.param("pageNo", "4567890908909")
+						.param("pageSize", "8")
+						.contentType(MediaType.APPLICATION_JSON_VALUE))
+
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
+				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
+
+		verify(partnerManagementService, never())
+				.getAllPartnerPolicyRequests(any(), any(), any(), any(), any());
+	}
+
+	@Test
+	@WithMockUser(roles = {"PARTNER_ADMIN"})
+	public void getAllApiKeyRequestsWithVeryLargePageNoReturnsValidationError() throws Exception {
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/partner-api-keys")
+						.param("pageNo", "4567890908909")
+						.param("pageSize", "8")
+						.contentType(MediaType.APPLICATION_JSON_VALUE))
+
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
+				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
+
+		verify(partnerManagementService, never())
+				.getAllApiKeyRequests(any(), any(), any(), any(), any());
+	}
+
+	@Test
+	@WithMockUser(roles = {"PARTNER_ADMIN"})
+	public void getAllApiKeyRequestsV2WithVeryLargePageNoReturnsValidationError() throws Exception {
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/partner-api-keys/v2")
+						.param("pageNo", "4567890908909")
+						.param("pageSize", "8")
+						.contentType(MediaType.APPLICATION_JSON_VALUE))
+
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
+				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
+
+		verify(partnerManagementService, never())
+				.getAllApiKeyRequestsV2(any(), any(), any(), any(), any());
+	}
+
+	@Test
+	@WithMockUser(roles = {"PARTNER_ADMIN"})
+	public void getBioextractorConfigurationsWithVeryLargePageNoReturnsValidationError() throws Exception {
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/bio-extractor-configurations")
+						.param("pageNo", "4567890908909")
+						.param("pageSize", "8")
+						.contentType(MediaType.APPLICATION_JSON_VALUE))
+
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
+				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
+
+		verify(partnerManagementService, never())
+				.getBioextractorConfigurations(any(), any(), any(), any(), any());
+	}
+
+	@Test
+	@WithMockUser(roles = {"PARTNER_ADMIN"})
+	public void getOidcClientsWithVeryLargePageNoReturnsValidationError() throws Exception {
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/oidc-clients")
+						.param("pageNo", "4567890908909")
+						.param("pageSize", "8")
+						.contentType(MediaType.APPLICATION_JSON_VALUE))
+
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
+				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
+
+		verify(clientManagementService, never())
+				.getPartnersClientsV2(any(), any(), any(), any(), any());
+	}
+
+	@Test
+	@WithMockUser(roles = {"PARTNER_ADMIN"})
+	public void getNotificationsWithVeryLargePageNoReturnsValidationError() throws Exception {
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/notifications")
+						.param("pageNo", "4567890908909")
+						.param("pageSize", "4")
+						.contentType(MediaType.APPLICATION_JSON_VALUE))
+
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
+				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
+	}
+
+	@Test
+	@WithMockUser(roles = {"PARTNER_ADMIN"})
+	public void getMispLicensesWithVeryLargePageNoReturnsValidationError() throws Exception {
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/misp-licenses")
+						.param("pageNo", "4567890908909")
+						.param("pageSize", "8")
+						.contentType(MediaType.APPLICATION_JSON_VALUE))
+
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.errors[0].errorCode").value("PMS_PRT_360"))
+				.andExpect(jsonPath("$.errors[0].message").value("Invalid Page No"));
+
+		verify(infraProviderService, never())
+				.getAllMISPLicenses(any(), any(), any(), any(), any());
+	}
+
+	@Test
 	@WithMockUser(roles = {"PARTNERMANAGER"})
 	public void getPartnersDeatilsTest() throws Exception {
 		PartnerDetailsResponse partnerDetailsResponse = new PartnerDetailsResponse();
@@ -1053,7 +1197,7 @@ public class PartnerManagementControllerTest {
 
 		ResponseWrapperV2<PageResponseV2Dto<PartnerPolicyRequestSummaryDto>> actual =
 				partnerManagementController.getAllPartnerPolicyRequests(
-						null, null, 0, 10,
+						null, null, "0", 10,
 						"p1", null,
 						null, null, null, null, null, null, null
 				);


### PR DESCRIPTION
[MOSIP-44959]

[MOSIP-44959]: https://mosip.atlassian.net/browse/MOSIP-44959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized pagination input across list endpoints: pageNo is parsed/validated and oversized or invalid values return a clear validation error.

* **Tests**
  * Added controller tests verifying very-large/invalid pageNo scenarios for multiple endpoints to ensure validation and that services are not invoked on invalid input.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/partner-management-services/pull/1849)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->