### PR TITLE
MOSIP-1903: Update negative test cases to validate PMS_PS_ERROR_009 for invalid or malformed status parameters.

### DIFF
--- a/api-test/src/main/resources/pms/ABISPartnerV3/GetListofPartnersAssociatedwithLoggedinUserABIS/GetListofPartnersAssociatedwithLoggedinUserABISNegTC.yml
+++ b/api-test/src/main/resources/pms/ABISPartnerV3/GetListofPartnersAssociatedwithLoggedinUserABIS/GetListofPartnersAssociatedwithLoggedinUserABISNegTC.yml
@@ -17,39 +17,47 @@ GetListofPartnersAssociatedwithLoggedinUserABISNegTC:
         {
            "errorCode": "KER-ATH-401"
         }
-     ] 
+     ]
 }'
   Pms_GetListofPartnersAssociatedwithLoggedinUserABISNegTC_With_Empty_Status_Neg:
     endPoint: /v1/partnermanager/partners/v3
     uniqueIdentifier: TC_GetListofPartnersAssociatedwithLoggedinUserABISNegTC_02
-    description: Validate that the API successfully processes the request when retrieving ABIS partners with an empty status parameter
+    description: Validate that the API will fail when retrieving ABIS partners with an empty status parameter
     role: partneradmin
     restMethod: get
-    checkErrorsOnlyInResponse: true
     inputTemplate: pms/ABISPartnerV3/GetListofPartnersAssociatedwithLoggedinUserABIS/GetListofPartnersAssociatedwithLoggedinUserABIS
-    outputTemplate: pms/ABISPartnerV3/GetListofPartnersAssociatedwithLoggedinUserABIS/GetListofPartnersAssociatedwithLoggedinUserABISResult
+    outputTemplate: pms/error
     input: '{
       "status": "",
       "policyGroupAvailable": "true",
       "partnerType": "ABIS_Partner"
 }'
     output: '{
+    "errors": [
+      {
+         "errorCode": "PMS_PS_ERROR_009"
+       }
+    ]
 }'
   Pms_GetListofPartnersAssociatedwithLoggedinUserABISNegTC_With_Uppercase_Status_APPROVED_Neg:
     endPoint: /v1/partnermanager/partners/v3
     uniqueIdentifier: TC_GetListofPartnersAssociatedwithLoggedinUserABISNegTC_03
-    description: Validate that the API successfully processes the request when retrieving ABIS partners using an uppercase status value (APPROVED)
+    description: Validate that the API will fail when retrieving ABIS partners using an uppercase status value (APPROVED)
     role: partneradmin
     restMethod: get
-    checkErrorsOnlyInResponse: true
     inputTemplate: pms/ABISPartnerV3/GetListofPartnersAssociatedwithLoggedinUserABIS/GetListofPartnersAssociatedwithLoggedinUserABIS
-    outputTemplate: pms/ABISPartnerV3/GetListofPartnersAssociatedwithLoggedinUserABIS/GetListofPartnersAssociatedwithLoggedinUserABISResult
+    outputTemplate: pms/error
     input: '{
       "status": "APPROVED",
       "policyGroupAvailable": "true",
       "partnerType": "ABIS_Partner"
 }'
     output: '{
+    "errors": [
+      {
+         "errorCode": "PMS_PS_ERROR_009"
+      }
+    ]
 }'
   Pms_GetListofPartnersAssociatedwithLoggedinUserABISNegTC_With_SpecialCharacter_Status_Neg:
     endPoint: /v1/partnermanager/partners/v3
@@ -205,23 +213,27 @@ GetListofPartnersAssociatedwithLoggedinUserABISNegTC:
         {
            "errorCode": "PMS_POLICY_ERROR_031"
         }
-     ] 
+     ]
 }'
   Pms_GetListofPartnersAssociatedwithLoggedinUserABISNegTC_With_Invalid_Status_And_Valid_PartnerType_Neg:
     endPoint: /v1/partnermanager/partners/v3
     uniqueIdentifier: TC_GetListofPartnersAssociatedwithLoggedinUserABISNegTC_12
-    description: Validate that the API successfully processes the request when retrieving ABIS partners using an invalid status and a valid partnerType
+    description: Validate that the API will fail when retrieving ABIS partners using an invalid status and a valid partnerType
     role: partneradmin
     restMethod: get
-    checkErrorsOnlyInResponse: true
     inputTemplate: pms/ABISPartnerV3/GetListofPartnersAssociatedwithLoggedinUserABIS/GetListofPartnersAssociatedwithLoggedinUserABIS
-    outputTemplate: pms/ABISPartnerV3/GetListofPartnersAssociatedwithLoggedinUserABIS/GetListofPartnersAssociatedwithLoggedinUserABISResult
+    outputTemplate: pms/error
     input: '{
       "status": "invalidstatus",
       "policyGroupAvailable": "true",
       "partnerType": "ABIS_Partner"
 }'
     output: '{
+    "errors": [
+      {
+         "errorCode": "PMS_PS_ERROR_009"
+      }
+    ]
 }'
   Pms_GetListofPartnersAssociatedwithLoggedinUserABISNegTC_With_Valid_Status_And_Invalid_PartnerType_Neg:
     endPoint: /v1/partnermanager/partners/v3

--- a/api-test/src/main/resources/pms/MAPartnerV3/GetListofPartnersAssociatedwithLoggedinUserMA/GetListofPartnersAssociatedwithLoggedinUserMA.yml
+++ b/api-test/src/main/resources/pms/MAPartnerV3/GetListofPartnersAssociatedwithLoggedinUserMA/GetListofPartnersAssociatedwithLoggedinUserMA.yml
@@ -40,18 +40,22 @@ GetListofPartnersAssociatedwithLoggedinUserMA:
   Pms_GetListofPartnersAssociatedwithLoggedinUserMA_With_Empty_Status_Neg:
     endPoint: /v1/partnermanager/partners/v3
     uniqueIdentifier: TC_GetListofPartnersAssociatedwithLoggedinUserMA_03
-    description: Validate that the API successfully processes the request when retrieving MA partners with an empty status parameter
+    description: Validate that the API will fail when retrieving MA partners with an empty status parameter
     role: partneradmin
-    checkErrorsOnlyInResponse: true
     restMethod: get
     inputTemplate: pms/MAPartnerV3/GetListofPartnersAssociatedwithLoggedinUserMA/GetListofPartnersAssociatedwithLoggedinUserMA
-    outputTemplate: pms/MAPartnerV3/GetListofPartnersAssociatedwithLoggedinUserMA/GetListofPartnersAssociatedwithLoggedinUserResultMA
+    outputTemplate: pms/error
     input: '{
       "status": "",
       "policyGroupAvailable": "true",
       "partnerType": "Manual_Adjudication"
     }'
     output: '{
+    "errors": [
+       {
+          "errorCode": "PMS_PS_ERROR_009"
+       }
+    ]
 }'
 
   Pms_GetListofPartnersAssociatedwithLoggedinUserMA_With_SpecialCharacter_Status_Neg:
@@ -95,18 +99,22 @@ GetListofPartnersAssociatedwithLoggedinUserMA:
   Pms_GetListofPartnersAssociatedwithLoggedinUserMA_With_CaseSensitive_Status_Neg:
     endPoint: /v1/partnermanager/partners/v3
     uniqueIdentifier: TC_GetListofPartnersAssociatedwithLoggedinUserMA_06
-    description: Validate that the API retrieves the list of Manual Adjudication (MA) partners with Case-sensitive(Approved) status associated with the logged-in Partner Admin user.
+    description: Validate that the API will give error with Case-sensitive(Approved) status associated with the logged-in Partner Admin user.
     role: partneradmin
-    checkErrorsOnlyInResponse: true
     restMethod: get
     inputTemplate: pms/MAPartnerV3/GetListofPartnersAssociatedwithLoggedinUserMA/GetListofPartnersAssociatedwithLoggedinUserMA
-    outputTemplate: pms/MAPartnerV3/GetListofPartnersAssociatedwithLoggedinUserMA/GetListofPartnersAssociatedwithLoggedinUserResultMA
+    outputTemplate: pms/error
     input: '{
       "status": "Approved",
       "policyGroupAvailable": "true",
       "partnerType": "Manual_Adjudication"
     }'
     output: '{
+    "errors": [
+      {
+         "errorCode": "PMS_PS_ERROR_009"
+      }
+    ]
 }'
 
   Pms_GetListofPartnersAssociatedwithLoggedinUserMA_With_UpperCase_Status_Neg:
@@ -115,15 +123,19 @@ GetListofPartnersAssociatedwithLoggedinUserMA:
     description: Validate that the API does not return MA partners when the status is provided in uppercase ("APPROVED") instead of the expected lowercase format.
     role: partneradmin
     restMethod: get
-    checkErrorsOnlyInResponse: true
     inputTemplate: pms/MAPartnerV3/GetListofPartnersAssociatedwithLoggedinUserMA/GetListofPartnersAssociatedwithLoggedinUserMA
-    outputTemplate: pms/MAPartnerV3/GetListofPartnersAssociatedwithLoggedinUserMA/GetListofPartnersAssociatedwithLoggedinUserResultMA
+    outputTemplate: pms/error
     input: '{
       "status": "APPROVED",
       "policyGroupAvailable": "true",
       "partnerType": "Manual_Adjudication"
     }'
     output: '{
+    "errors": [
+      {
+         "errorCode": "PMS_PS_ERROR_009"
+       }
+    ]
 }'
 
   Pms_GetListofPartnersAssociatedwithLoggedinUserMA_With_PolicyGroupAvailable_As_False_Smoke:
@@ -306,18 +318,22 @@ GetListofPartnersAssociatedwithLoggedinUserMA:
   Pms_GetListofPartnersAssociatedwithLoggedinUserMA_With_Invalid_Status_And_Valid_PartnerType_Neg:
     endPoint: /v1/partnermanager/partners/v3
     uniqueIdentifier: TC_GetListofPartnersAssociatedwithLoggedinUserMA_17
-    description: Validate that the API successfully processes the request when retrieving MA partners using an invalid status and a valid partnerType
+    description: Validate that the API will give error when retrieving MA partners using an invalid status and a valid partnerType
     role: partneradmin
     restMethod: get
-    checkErrorsOnlyInResponse: true
     inputTemplate: pms/MAPartnerV3/GetListofPartnersAssociatedwithLoggedinUserMA/GetListofPartnersAssociatedwithLoggedinUserMA
-    outputTemplate: pms/MAPartnerV3/GetListofPartnersAssociatedwithLoggedinUserMA/GetListofPartnersAssociatedwithLoggedinUserResultMA
+    outputTemplate: pms/error
     input: '{
       "status": "invalidstatus",
       "policyGroupAvailable": "true",
       "partnerType": "Manual_Adjudication"
     }'
     output: '{
+    "errors": [
+      {
+         "errorCode": "PMS_PS_ERROR_009"
+       }
+     ]
     }'
   Pms_GetListofPartnersAssociatedwithLoggedinUserMA_With_Valid_Status_And_Invalid_PartnerType_Neg:
     endPoint: /v1/partnermanager/partners/v3

--- a/api-test/src/main/resources/pms/MISPPartnerV3/GetListofPartnersAssociatedwithLoggedinUser/GetListofPartnersAssociatedwithLoggedinUserNegSce.yml
+++ b/api-test/src/main/resources/pms/MISPPartnerV3/GetListofPartnersAssociatedwithLoggedinUser/GetListofPartnersAssociatedwithLoggedinUserNegSce.yml
@@ -144,16 +144,20 @@ GetListofPartnersAssociatedwithLoggedinUserNegSce:
       uniqueIdentifier: TC_GetListofPartnersAssociatedwithLoggedinUsernegSce_08
       description: Validate that the API returns an error when attempting to retrieve the list of partners associated with the logged in user using an invalid status with a valid partner type
       role: partneradmin
-      checkErrorsOnlyInResponse: true
       restMethod: get
       inputTemplate: pms/MISPPartnerV3/GetListofPartnersAssociatedwithLoggedinUser/GetListofPartnersAssociatedwithLoggedinUser
-      outputTemplate: pms/MISPPartnerV3/GetListofPartnersAssociatedwithLoggedinUser/GetListofPartnersAssociatedwithLoggedinUserResult
+      outputTemplate: pms/error
       input: '{
       "status": "approvedInprogress",
       "policyGroupAvailable": "true",
       "partnerType": "MISP_Partner"
 }'
       output: '{
+      "errors": [
+        {
+           "errorCode": "PMS_PS_ERROR_009"
+        }
+        ]
 }'
    Pms_GetListofPartnersAssociatedwithLoggedinUserNegSce_validStatus_invalidPartnerType_Neg:
       endPoint: /v1/partnermanager/partners/v3
@@ -191,7 +195,7 @@ GetListofPartnersAssociatedwithLoggedinUserNegSce:
       output: '{
         "errors": [
           {
-             "errorCode": "PMS_POLICY_ERROR_030"
+             "errorCode": "PMS_PS_ERROR_009"
            }
       ] 
 }'


### PR DESCRIPTION
Updates automated negative test cases across ABIS, Manual Adjudication (MA), and MISP partner retrieval scenarios to ensure the API correctly validates and throws a standardized PMS_PS_ERROR_009 error code when an invalid, uppercase, or empty status parameter is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases across multiple API modules to properly validate error responses for invalid inputs (empty status, case-sensitive values, invalid parameters).
  * Enhanced error code assertions to ensure consistent validation behavior for authentication failures, parameter validation, and role-based access scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/partner-management-services/pull/1906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->