### PR TITLE
#1902: GET partner-policy-requests bio-extractors and credential-type…

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/manager/service/impl/PartnerManagementServiceImpl.java
@@ -1053,22 +1053,38 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 			String partnerId = parentRequest.getPartner().getId();
 			validateLoggedInUserAuthorization(partnerId);
 
-			List<PartnerPolicyBioextractRequest> rows =
-					partnerPolicyBioextractRequestRepository
-							.findByPartnerPolicyRequestIdOrderByCrDtimesAsc(parentRequest.getId());
 			responseWrapper.setPartnerPolicyRequestId(parentRequest.getId());
 			responseWrapper.setStatusCode(parentRequest.getStatusCode());
 
-			List<BioExtractorsDto> extractors = (rows == null ? List.<BioExtractorsDto>of() :
-					rows.stream().map(r -> {
-						BioExtractorsDto dto = new BioExtractorsDto();
-						dto.setAttributeName(r.getAttributeName());
-						dto.setBiometric(r.getBiometricModality());
-						dto.setBiometricSubTypes(r.getBiometricSubTypes());
-						dto.setExtractorProvider(r.getExtractorProvider());
-						dto.setExtractorProviderVersion(r.getExtractorProviderVersion());
-						return dto;
-					}).toList());
+			List<BioExtractorsDto> extractors;
+			if (APPROVED.equalsIgnoreCase(parentRequest.getStatusCode())) {
+				List<BiometricExtractorProvider> finalRows = extractorProviderRepository
+						.findActiveByPartnerAndPolicyId(partnerId, parentRequest.getPolicyId());
+				extractors = (finalRows == null ? List.<BioExtractorsDto>of() :
+						finalRows.stream().map(r -> {
+							BioExtractorsDto dto = new BioExtractorsDto();
+							dto.setAttributeName(r.getAttributeName());
+							dto.setBiometric(r.getBiometricModality());
+							dto.setBiometricSubTypes(r.getBiometricSubTypes());
+							dto.setExtractorProvider(r.getExtractorProvider());
+							dto.setExtractorProviderVersion(r.getExtractorProviderVersion());
+							return dto;
+						}).toList());
+			} else {
+				List<PartnerPolicyBioextractRequest> rows =
+						partnerPolicyBioextractRequestRepository
+								.findByPartnerPolicyRequestIdOrderByCrDtimesAsc(parentRequest.getId());
+				extractors = (rows == null ? List.<BioExtractorsDto>of() :
+						rows.stream().map(r -> {
+							BioExtractorsDto dto = new BioExtractorsDto();
+							dto.setAttributeName(r.getAttributeName());
+							dto.setBiometric(r.getBiometricModality());
+							dto.setBiometricSubTypes(r.getBiometricSubTypes());
+							dto.setExtractorProvider(r.getExtractorProvider());
+							dto.setExtractorProviderVersion(r.getExtractorProviderVersion());
+							return dto;
+						}).toList());
+			}
 
 			BioExtractorsResponseDto responseDto = new BioExtractorsResponseDto();
 			responseDto.setExtractors(extractors);
@@ -1199,18 +1215,29 @@ public class PartnerManagementServiceImpl implements PartnerManagerService {
 			String partnerId = parentRequest.getPartner().getId();
 			validateLoggedInUserAuthorization(partnerId);
 
-			Optional<PartnerPolicyCredentialTypeRequest> row =
-					partnerPolicyCredentialTypeRequestRepository
-							.findFirstByPartnerPolicyRequestIdOrderByCrDtimesAsc(parentRequest.getId());
 			responseWrapper.setPartnerPolicyRequestId(parentRequest.getId());
 			responseWrapper.setStatusCode(parentRequest.getStatusCode());
 
 			CredentialTypesResponseDto responseDto = new CredentialTypesResponseDto();
 			String credentialType = null;
-			if (row.isPresent()) {
-				credentialType = row.get().getCredentialType();
-				if (credentialType != null) {
-					credentialType = credentialType.trim().isEmpty() ? null : credentialType.trim();
+			if (APPROVED.equalsIgnoreCase(parentRequest.getStatusCode())) {
+				List<PartnerPolicyCredentialType> finalRows = partnerPolicyCredentialTypeRepository
+						.findByPartnerIdAndPolicyIdAndIsActiveTrue(partnerId, parentRequest.getPolicyId());
+				if (finalRows != null && !finalRows.isEmpty()) {
+					credentialType = finalRows.get(0).getId().getCredentialType();
+					if (credentialType != null) {
+						credentialType = credentialType.trim().isEmpty() ? null : credentialType.trim();
+					}
+				}
+			} else {
+				Optional<PartnerPolicyCredentialTypeRequest> row =
+						partnerPolicyCredentialTypeRequestRepository
+								.findFirstByPartnerPolicyRequestIdOrderByCrDtimesAsc(parentRequest.getId());
+				if (row.isPresent()) {
+					credentialType = row.get().getCredentialType();
+					if (credentialType != null) {
+						credentialType = credentialType.trim().isEmpty() ? null : credentialType.trim();
+					}
 				}
 			}
 			responseDto.setCredentialType(credentialType);

--- a/partner/pms-common/src/main/java/io/mosip/pms/common/repository/BiometricExtractorProviderRepository.java
+++ b/partner/pms-common/src/main/java/io/mosip/pms/common/repository/BiometricExtractorProviderRepository.java
@@ -13,6 +13,9 @@ public interface BiometricExtractorProviderRepository extends JpaRepository<Biom
 
 	@Query(value = "select * from partner_policy_bioextract ppb where ppb.part_id=?1 and ppb.policy_id = ?2",nativeQuery = true)
 	List<BiometricExtractorProvider> findByPartnerAndPolicyId(String partnerId, String policyId);
+
+	@Query(value = "select * from partner_policy_bioextract ppb where ppb.part_id=?1 and ppb.policy_id = ?2 and (ppb.is_deleted is null or ppb.is_deleted = false)",nativeQuery = true)
+	List<BiometricExtractorProvider> findActiveByPartnerAndPolicyId(String partnerId, String policyId);
 	
 	@Query(value = "select * from partner_policy_bioextract ppb where ppb.part_id=?1 and ppb.policy_id = ?2 and ppb.attribute_name =?3",nativeQuery = true)
 	BiometricExtractorProvider findByPartnerAndPolicyIdAndAttributeName(String partnerId, String policyId, String attributeName);

--- a/partner/pms-common/src/main/java/io/mosip/pms/common/repository/BiometricExtractorProviderRepository.java
+++ b/partner/pms-common/src/main/java/io/mosip/pms/common/repository/BiometricExtractorProviderRepository.java
@@ -14,7 +14,7 @@ public interface BiometricExtractorProviderRepository extends JpaRepository<Biom
 	@Query(value = "select * from partner_policy_bioextract ppb where ppb.part_id=?1 and ppb.policy_id = ?2",nativeQuery = true)
 	List<BiometricExtractorProvider> findByPartnerAndPolicyId(String partnerId, String policyId);
 
-	@Query(value = "select * from partner_policy_bioextract ppb where ppb.part_id=?1 and ppb.policy_id = ?2 and (ppb.is_deleted is null or ppb.is_deleted = false)",nativeQuery = true)
+	@Query(value = "select * from partner_policy_bioextract ppb where ppb.part_id=?1 and ppb.policy_id = ?2 and (ppb.is_deleted is null or ppb.is_deleted = false) order by ppb.cr_dtimes asc",nativeQuery = true)
 	List<BiometricExtractorProvider> findActiveByPartnerAndPolicyId(String partnerId, String policyId);
 	
 	@Query(value = "select * from partner_policy_bioextract ppb where ppb.part_id=?1 and ppb.policy_id = ?2 and ppb.attribute_name =?3",nativeQuery = true)


### PR DESCRIPTION
…s serve data from final tables when approved

When a partner-policy request has statusCode 'approved', the GET /partner-policy-requests/{requestId}/bio-extractors-request and GET /partner-policy-requests/{requestId}/credential-types-request endpoints now read from the final mapping tables (partner_policy_bioextract and partner_policy_credential_type) instead of the request tables. This fixes visibility for partners onboarded via CSV import, whose data exists only in the final tables and not in the request tables.

Also adds findActiveByPartnerAndPolicyId to BiometricExtractorProviderRepository to exclude soft-deleted records in the approved read path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retrieval of bio-extractor lists depending on request status to ensure approved requests use active production data.
  * Sourced credential types from active production records for approved requests, while preserving pending-request behavior for others.
  * Added null/blank-safe trimming for credential type values to prevent incorrect or empty entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->