### PR TITLE
#1943: PMS Service New API GET /partners/{partnerId}/policies/{policyId}/credentialTypes

### DIFF
--- a/docs/partner_management_service_api_documentation.json
+++ b/docs/partner_management_service_api_documentation.json
@@ -2033,7 +2033,7 @@
                 }
             }
         },
-        "/partners/{partnerId}/credentialtypes/{policyId}": {
+        "/partners/{partnerId}/policies/{policyId}/credentialTypes": {
             "get": {
                 "tags": [
                     "partner-service-controller"

--- a/docs/partner_management_service_api_documentation.json
+++ b/docs/partner_management_service_api_documentation.json
@@ -2033,7 +2033,7 @@
                 }
             }
         },
-        "/partners/{partnerId}/policies/{policyId}/credentialTypes": {
+        "/partners/{partnerId}/policies/{policyId}/credential-types": {
             "get": {
                 "tags": [
                     "partner-service-controller"

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/controller/PartnerServiceController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/controller/PartnerServiceController.java
@@ -222,7 +222,7 @@ public class PartnerServiceController {
 	}
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getGetpartnerscredentialtypes())")
-	@RequestMapping(value = "/{partnerId}/policies/{policyId}/credentialTypes", method = RequestMethod.GET)
+	@RequestMapping(value = "/{partnerId}/policies/{policyId}/credential-types", method = RequestMethod.GET)
 	@Operation(summary = "Get credential types for a partner and policy", description = "Returns all active credential types mapped to the given partner and policy from the partner_policy_credential_type table.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "OK"),

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/controller/PartnerServiceController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/controller/PartnerServiceController.java
@@ -222,7 +222,7 @@ public class PartnerServiceController {
 	}
 
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getGetpartnerscredentialtypes())")
-	@RequestMapping(value = "/{partnerId}/credentialtypes/{policyId}", method = RequestMethod.GET)
+	@RequestMapping(value = "/{partnerId}/policies/{policyId}/credentialTypes", method = RequestMethod.GET)
 	@Operation(summary = "Get credential types for a partner and policy", description = "Returns all active credential types mapped to the given partner and policy from the partner_policy_credential_type table.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "OK"),

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerServiceControllerTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerServiceControllerTest.java
@@ -203,7 +203,7 @@ public class PartnerServiceControllerTest {
         CredentialTypesListDto dto = new CredentialTypesListDto();
         dto.setCredentialTypes(List.of("euin"));
         when(partnerService.getCredentialTypesByPartnerAndPolicy("12345", "p001")).thenReturn(dto);
-        mockMvc.perform(MockMvcRequestBuilders.get("/partners/12345/policies/p001/credentialTypes"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/partners/12345/policies/p001/credential-types"))
                 .andExpect(status().isOk());
     }
 
@@ -213,7 +213,7 @@ public class PartnerServiceControllerTest {
         CredentialTypesListDto dto = new CredentialTypesListDto();
         dto.setCredentialTypes(List.of("qrcode"));
         when(partnerService.getCredentialTypesByPartnerAndPolicy("12345", "p001")).thenReturn(dto);
-        mockMvc.perform(MockMvcRequestBuilders.get("/partners/12345/policies/p001/credentialTypes"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/partners/12345/policies/p001/credential-types"))
                 .andExpect(status().isOk());
     }
 
@@ -223,7 +223,7 @@ public class PartnerServiceControllerTest {
         CredentialTypesListDto dto = new CredentialTypesListDto();
         dto.setCredentialTypes(List.of("auth"));
         when(partnerService.getCredentialTypesByPartnerAndPolicy("adminPartner", "pol99")).thenReturn(dto);
-        mockMvc.perform(MockMvcRequestBuilders.get("/partners/adminPartner/policies/pol99/credentialTypes"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/partners/adminPartner/policies/pol99/credential-types"))
                 .andExpect(status().isOk());
     }
 

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerServiceControllerTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/partner/controller/PartnerServiceControllerTest.java
@@ -203,7 +203,7 @@ public class PartnerServiceControllerTest {
         CredentialTypesListDto dto = new CredentialTypesListDto();
         dto.setCredentialTypes(List.of("euin"));
         when(partnerService.getCredentialTypesByPartnerAndPolicy("12345", "p001")).thenReturn(dto);
-        mockMvc.perform(MockMvcRequestBuilders.get("/partners/12345/credentialtypes/p001"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/partners/12345/policies/p001/credentialTypes"))
                 .andExpect(status().isOk());
     }
 
@@ -213,7 +213,7 @@ public class PartnerServiceControllerTest {
         CredentialTypesListDto dto = new CredentialTypesListDto();
         dto.setCredentialTypes(List.of("qrcode"));
         when(partnerService.getCredentialTypesByPartnerAndPolicy("12345", "p001")).thenReturn(dto);
-        mockMvc.perform(MockMvcRequestBuilders.get("/partners/12345/credentialtypes/p001"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/partners/12345/policies/p001/credentialTypes"))
                 .andExpect(status().isOk());
     }
 
@@ -223,7 +223,7 @@ public class PartnerServiceControllerTest {
         CredentialTypesListDto dto = new CredentialTypesListDto();
         dto.setCredentialTypes(List.of("auth"));
         when(partnerService.getCredentialTypesByPartnerAndPolicy("adminPartner", "pol99")).thenReturn(dto);
-        mockMvc.perform(MockMvcRequestBuilders.get("/partners/adminPartner/credentialtypes/pol99"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/partners/adminPartner/policies/pol99/credentialTypes"))
                 .andExpect(status().isOk());
     }
 


### PR DESCRIPTION
…{policyId}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Updates**
  * Credential type retrieval endpoint path restructured from `/partners/{partnerId}/credentialtypes/{policyId}` to `/partners/{partnerId}/policies/{policyId}/credential-types`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->