### PR TITLE
#1893 : Updated PATCH with response and added NOTE for POST

### DIFF
--- a/docs/partner_management_service_api_documentation.json
+++ b/docs/partner_management_service_api_documentation.json
@@ -3426,7 +3426,7 @@
                     "misp-license-controller"
                 ],
                 "summary": "NEW: Generate MISP License Key",
-                "description": "Available since release-1.3.0.\n\nThis endpoint is used to generate a MISP License Key for a given MISP partner.\n\nThis endpoint is configured only for users with the PARTNER_ADMIN role.\nIt is an upgrade of the earlier POST /misps endpoint.\n- Supports generation of multiple MISP license keys for the same partner.\n- Allows the user to enter and set an expiry date for MISP license key.\n- `licenseKeyName` field was added to support the generation of multiple MISP license keys with distinct names.",
+                "description": "Available since release-1.3.0.\n\nThis endpoint is used to generate a MISP License Key for a given MISP partner.\n\nThis endpoint is configured only for users with the PARTNER_ADMIN role.\nIt is an upgrade of the earlier POST /misps endpoint.\n- Supports generation of multiple MISP license keys for the same partner.\n- Allows the user to enter and set an expiry date for MISP license key.\n- `licenseKeyName` field was added to support the generation of multiple MISP license keys with distinct names.\n- Note: The `licenseKey` is returned only once at the time of creation and will not be available for retrieval thereafter.",
                 "operationId": "generate-misp-license",
                 "requestBody": {
                     "required": true,
@@ -3939,10 +3939,6 @@
                                                     "type": "string",
                                                     "description": "Unique identifier of the Policy"
                                                 },
-                                                "licenseKey": {
-                                                    "type": "string",
-                                                    "description": "Unique license key for the MISP Partner"
-                                                },
                                                 "licenseKeyName": {
                                                     "type": "string",
                                                     "description": "Name of the MISP License Key"
@@ -3954,11 +3950,6 @@
                                                         "INACTIVE"
                                                     ],
                                                     "description": "Current status of the MISP License Key"
-                                                },
-                                                "expiryDateTime": {
-                                                    "type": "string",
-                                                    "format": "date-time",
-                                                    "description": "Expiry date and time of the MISP License Key in ISO format"
                                                 }
                                             }
                                         },
@@ -3990,10 +3981,8 @@
                                                 "mispLicenseId": "4375037d-d069-4670-8b8b-97cb53d4d36e",
                                                 "partnerId": "partner123",
                                                 "policyId": "policy789",
-                                                "licenseKey": "********xyz",
                                                 "licenseKeyName": "MISP License Key 1",
-                                                "status": "INACTIVE",
-                                                "expiryDateTime": "2026-12-31T10:00:00Z"
+                                                "status": "INACTIVE"
                                             },
                                             "errors": []
                                         }

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/misp/controller/MISPLicenseController.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/misp/controller/MISPLicenseController.java
@@ -47,6 +47,7 @@ import io.mosip.pms.partner.misp.dto.MISPLicenseRequestDtoV2;
 import io.mosip.pms.partner.misp.dto.MISPLicenseResponseDtoV2;
 import io.mosip.pms.partner.misp.dto.MISPLicenseDetailsDto;
 import io.mosip.pms.partner.misp.dto.MISPLicensePatchRequestDto;
+import io.mosip.pms.partner.misp.dto.MISPDeactivateResponseDto;
 import io.mosip.pms.partner.misp.service.InfraServiceProviderService;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
@@ -203,7 +204,7 @@ public class MISPLicenseController {
 	@PostMapping("/misp-licenses")
 	@PreAuthorize("hasAnyRole(@authorizedRoles.getPostgeneratemisplicense())")
 	@Operation(summary = "This endpoint is used to generate a MISP License Key for a given MISP partner.",
-			description = "Available since release-1.3.0. This endpoint is configured only for users with the PARTNER_ADMIN role. It is an upgrade of the earlier POST /misps endpoint.")
+			description = "Available since release-1.3.0. This endpoint is configured only for users with the PARTNER_ADMIN role. It is an upgrade of the earlier POST /misps endpoint. Note: The licenseKey is returned only once at the time of creation and will not be available for retrieval thereafter.")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "OK"),
 			@ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(hidden = true))),
@@ -240,9 +241,9 @@ public class MISPLicenseController {
 			@ApiResponse(responseCode = "200", description = "OK"),
 			@ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(hidden = true))),
 			@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(hidden = true)))})
-	public ResponseWrapperV2<MISPLicenseResponseDtoV2> updateMISPLicense(@PathVariable @Valid String mispLicenseId,
+	public ResponseWrapperV2<MISPDeactivateResponseDto> updateMISPLicense(@PathVariable @Valid String mispLicenseId,
 			@RequestBody @Valid RequestWrapperV2<MISPLicensePatchRequestDto> requestWrapper) {
-		Optional<ResponseWrapperV2<MISPLicenseResponseDtoV2>> validationResponse = requestValidator.validate(patchUpdateMISPApiId, requestWrapper);
+		Optional<ResponseWrapperV2<MISPDeactivateResponseDto>> validationResponse = requestValidator.validate(patchUpdateMISPApiId, requestWrapper);
 		if (validationResponse.isPresent()) {
 			return validationResponse.get();
 		}

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/misp/dto/MISPDeactivateResponseDto.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/misp/dto/MISPDeactivateResponseDto.java
@@ -4,8 +4,9 @@ import lombok.Data;
 
 @Data
 public class MISPDeactivateResponseDto {
+    private String mispLicenseId;
     private String partnerId;
     private String policyId;
     private String licenseKeyName;
-    private String licenseKeyStatus;
+    private String status;
 }

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/misp/service/InfraServiceProviderService.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/misp/service/InfraServiceProviderService.java
@@ -11,6 +11,7 @@ import io.mosip.pms.common.response.dto.ResponseWrapperV2;
 import io.mosip.pms.device.response.dto.FilterResponseCodeDto;
 import io.mosip.pms.partner.misp.dto.MISPFilterDto;
 import io.mosip.pms.partner.misp.dto.MISPLicensePatchRequestDto;
+import io.mosip.pms.partner.misp.dto.MISPDeactivateResponseDto;
 import io.mosip.pms.partner.misp.dto.MISPLicenseResponseDto;
 import io.mosip.pms.partner.misp.dto.MISPLicenseSummaryDto;
 import io.mosip.pms.partner.misp.dto.MISPLicenseRequestDtoV2;
@@ -37,5 +38,5 @@ public interface InfraServiceProviderService {
 
 	public ResponseWrapperV2<MISPLicenseDetailsDto> getMISPLicenseDetails(String mispLicenseId);
 
-	public ResponseWrapperV2<MISPLicenseResponseDtoV2> updateMISPLicense(String mispLicenseId, MISPLicensePatchRequestDto request);
+	public ResponseWrapperV2<MISPDeactivateResponseDto> updateMISPLicense(String mispLicenseId, MISPLicensePatchRequestDto request);
 }

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/misp/service/impl/InfraProviderServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/misp/service/impl/InfraProviderServiceImpl.java
@@ -79,6 +79,7 @@ import io.mosip.pms.common.constant.PartnerConstants;
 import io.mosip.pms.partner.exception.PartnerServiceException;
 import io.mosip.pms.partner.misp.dto.MISPLicenseResponseDto;
 import io.mosip.pms.partner.misp.dto.MISPLicensePatchRequestDto;
+import io.mosip.pms.partner.misp.dto.MISPDeactivateResponseDto;
 import io.mosip.pms.partner.misp.exception.MISPErrorMessages;
 import io.mosip.pms.partner.misp.exception.MISPServiceException;
 import io.mosip.pms.partner.misp.service.InfraServiceProviderService;
@@ -735,8 +736,8 @@ public class InfraProviderServiceImpl implements InfraServiceProviderService {
 	}
 
 	@Override
-	public ResponseWrapperV2<MISPLicenseResponseDtoV2> updateMISPLicense(String mispLicenseId, MISPLicensePatchRequestDto request) {
-		ResponseWrapperV2<MISPLicenseResponseDtoV2> responseWrapper = new ResponseWrapperV2<>();
+	public ResponseWrapperV2<MISPDeactivateResponseDto> updateMISPLicense(String mispLicenseId, MISPLicensePatchRequestDto request) {
+		ResponseWrapperV2<MISPDeactivateResponseDto> responseWrapper = new ResponseWrapperV2<>();
 		try {
 			if (Objects.isNull(mispLicenseId) || mispLicenseId.trim().isBlank()) {
 				throw new MISPServiceException(MISPErrorMessages.MISP_LICENSE_NOT_FOUND_BY_ID.getErrorCode(),
@@ -768,13 +769,12 @@ public class InfraProviderServiceImpl implements InfraServiceProviderService {
 			entity.setUpdatedDateTime(LocalDateTime.now(ZoneId.of("UTC")));
 			MISPLicenseEntityV2 updated = mispLicenseV2Repository.save(entity);
 
-			MISPLicenseResponseDtoV2 responseDtoV2 = new MISPLicenseResponseDtoV2();
+			MISPDeactivateResponseDto responseDtoV2 = new MISPDeactivateResponseDto();
 			responseDtoV2.setMispLicenseId(updated.getMispLicenseId());
 			responseDtoV2.setPartnerId(updated.getMispId());
 			responseDtoV2.setPolicyId(updated.getPolicyId());
 			responseDtoV2.setLicenseKeyName(updated.getLicenseKeyName());
 			responseDtoV2.setStatus(updated.getIsActive() ? ACTIVE : INACTIVE);
-			responseDtoV2.setExpiryDateTime(updated.getValidToDate());
 
 			String updatedPolicyId = updated.getPolicyId();
 			if (updatedPolicyId != null && !updatedPolicyId.isBlank()) {

--- a/partner/partner-management-service/src/test/java/io/mosip/pms/test/misp/controller/MISPLicenseControllerTest.java
+++ b/partner/partner-management-service/src/test/java/io/mosip/pms/test/misp/controller/MISPLicenseControllerTest.java
@@ -399,11 +399,11 @@ public class MISPLicenseControllerTest {
 		return requestWrapper;
 	}
 
-	private ResponseWrapperV2<MISPLicenseResponseDtoV2> updateMISPResponseWrapper() {
-		ResponseWrapperV2<MISPLicenseResponseDtoV2> responseWrapper = new ResponseWrapperV2<>();
+	private ResponseWrapperV2<MISPDeactivateResponseDto> updateMISPResponseWrapper() {
+		ResponseWrapperV2<MISPDeactivateResponseDto> responseWrapper = new ResponseWrapperV2<>();
 		responseWrapper.setId("mosip.pms.update.misp.license.patch");
 		responseWrapper.setVersion("1.0");
-		MISPLicenseResponseDtoV2 response = new MISPLicenseResponseDtoV2();
+		MISPDeactivateResponseDto response = new MISPDeactivateResponseDto();
 		responseWrapper.setResponse(response);
 		return responseWrapper;
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the license key is shown only once when created and cannot be retrieved later.
  * Updated API examples and response details to match the current output.

* **Bug Fixes**
  * Adjusted the license update response to return the correct deactivation details.
  * Updated the response fields shown to users, including license ID, name, and status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->