### PR TITLE
#1760 , MOSIP-44073 : Removed Partner_Admin from pms-partner_type table

### DIFF
--- a/db_scripts/mosip_pms/dml/pms-partner_type.csv
+++ b/db_scripts/mosip_pms/dml/pms-partner_type.csv
@@ -2,7 +2,6 @@ code,partner_description,is_active,cr_by,cr_dtimes,is_policy_required
 Auth_Partner,Auth Partner,TRUE,superadmin,now(),TRUE
 Device_Provider,Device Provider,TRUE,superadmin,now(),FALSE
 Credential_Partner,Credential Partner,TRUE,superadmin,now(),TRUE
-Partner_Admin,Partner Admin,TRUE,superadmin,now(),FALSE
 FTM_Provider,FTM Provider,TRUE,superadmin,now(),FALSE
 Online_Verification_Partner,Online_Verification_Partner,TRUE,superadmin,now(),TRUE
 ABIS_Partner,ABIS Partner,TRUE,superadmin,now(),TRUE

--- a/db_upgrade_scripts/mosip_pms/sql/1.3.0-beta.5_to_1.3.0_rollback.sql
+++ b/db_upgrade_scripts/mosip_pms/sql/1.3.0-beta.5_to_1.3.0_rollback.sql
@@ -1,6 +1,14 @@
 \c mosip_pms
 
 -- -------------------------------------------------------------------------------------------------
+-- Rollback for Partner_Admin partner type removal
+-- -------------------------------------------------------------------------------------------------
+
+INSERT INTO pms.partner_type (code, partner_description, is_policy_required, is_active, cr_by, cr_dtimes)
+VALUES ('Partner_Admin', 'Partner Admin', FALSE, TRUE, 'superadmin', now())
+ON CONFLICT (code) DO NOTHING;
+
+-- -------------------------------------------------------------------------------------------------
 -- Rollback for MISP License surrogate PK migration (1.3.0)
 -- -------------------------------------------------------------------------------------------------
 

--- a/db_upgrade_scripts/mosip_pms/sql/1.3.0-beta.5_to_1.3.0_upgrade.sql
+++ b/db_upgrade_scripts/mosip_pms/sql/1.3.0-beta.5_to_1.3.0_upgrade.sql
@@ -50,3 +50,16 @@ SET attribute_name = 'photo',
     upd_dtimes = now()
 WHERE part_id = 'mpartner-default-auth'
   AND biometric_modality = 'face';
+
+-- -------------------------------------------------------------------------------------------------
+-- Remove unused Partner_Admin partner type
+-- -------------------------------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pms.partner WHERE partner_type_code = 'Partner_Admin') THEN
+        RAISE NOTICE 'Skipping removal of partner_type Partner_Admin: existing pms.partner rows still reference it';
+    ELSE
+        DELETE FROM pms.partner_type WHERE code = 'Partner_Admin';
+    END IF;
+END $$;

--- a/db_upgrade_scripts/mosip_pms/sql/1.3.0-beta.5_to_1.3.0_upgrade.sql
+++ b/db_upgrade_scripts/mosip_pms/sql/1.3.0-beta.5_to_1.3.0_upgrade.sql
@@ -58,7 +58,7 @@ WHERE part_id = 'mpartner-default-auth'
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pms.partner WHERE partner_type_code = 'Partner_Admin') THEN
-        RAISE NOTICE 'Skipping removal of partner_type Partner_Admin: existing pms.partner rows still reference it';
+        RAISE WARNING 'Skipping removal of partner_type Partner_Admin: existing pms.partner rows still reference it. Manual cleanup required: reassign or remove the referencing pms.partner rows, then delete pms.partner_type row with code = ''Partner_Admin''.';
     ELSE
         DELETE FROM pms.partner_type WHERE code = 'Partner_Admin';
     END IF;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade and rollback handling for partner type changes.
  * The system now safely avoids removing partner type data when it is still in use, and can restore it during rollback without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->