### PR TITLE
#1985 : Partner Certificate expiry Notifications for MOSIP Internal default partners

### DIFF
--- a/partner/partner-management-service/src/main/resources/bootstrap.properties
+++ b/partner/partner-management-service/src/main/resources/bootstrap.properties
@@ -249,7 +249,7 @@ mosip.pms.batch.job.api.key.expiry.periods=30,15,10,9,8,7,6,5,4,3,2,1,0
 mosip.pms.batch.job.misp.license.key.expiry.periods=30,15,10,9,8,7,6,5,4,3,2,1,0
 
 #specify the partner ids for which notifications are to be skipped
-mosip.pms.batch.job.skips.partner.ids=MOSIP.PROXY.SBI,mpartner-default-cert,mpartner-default-adjudication,mpartner-default-mobile,mpartner-default-print,mpartner-default-abis,mpartner-default-resident,mpartner-default-auth,mpartner-default-digitalcard,mpartner-default-esignet,
+mosip.pms.batch.job.skips.partner.ids=MOSIP.PROXY.SBI
 
 #email notification templates
 email.notification.partner.cert.expiry.template=PARTNER_CERT_EXPIRY_TEMPLATE

--- a/partner/partner-management-service/src/test/resources/application.properties
+++ b/partner/partner-management-service/src/test/resources/application.properties
@@ -418,7 +418,7 @@ mosip.pms.batch.job.sbi.expiry.periods=30,15,10,9,8,7,6,5,4,3,2,1,0
 mosip.pms.batch.job.api.key.expiry.periods=30,15,10,9,8,7,6,5,4,3,2,1,0
 
 #specify the partner ids for which notifications are to be skipped
-mosip.pms.batch.job.skips.partner.ids=MOSIP.PROXY.SBI,mpartner-default-cert,mpartner-default-adjudication,mpartner-default-mobile,mpartner-default-print,mpartner-default-abis,mpartner-default-resident,mpartner-default-auth,mpartner-default-digitalcard,mpartner-default-esignet,
+mosip.pms.batch.job.skips.partner.ids=MOSIP.PROXY.SBI
 
 #email notification templates
 email.notification.partner.cert.expiry.template=PARTNER_CERT_EXPIRY_TEMPLATE


### PR DESCRIPTION
…efault partners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated notification processing so only `MOSIP.PROXY.SBI` is excluded from partner notifications.
  * Aligned test configuration with the updated notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->