### PR TITLE
#1974 : MISP domain updated for Partner certificate expiry job

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/tasklets/util/BatchJobHelper.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/tasklets/util/BatchJobHelper.java
@@ -291,6 +291,8 @@ public class BatchJobHelper {
 			return PartnerConstants.PARTNER_DOMAIN_DEVICE;
 		case PartnerConstants.FTM_PROVIDER_PARTNER_TYPE:
 			return PartnerConstants.PARTNER_DOMAIN_FTM;
+		case PartnerConstants.MISP_PARTNER_TYPE:
+			return PartnerConstants.PARTNER_DOMAIN_MISP;
 		default:
 			return PartnerConstants.PARTNER_DOMAIN_AUTH;
 		}

--- a/partner/pms-common/src/main/java/io/mosip/pms/common/constant/PartnerConstants.java
+++ b/partner/pms-common/src/main/java/io/mosip/pms/common/constant/PartnerConstants.java
@@ -106,6 +106,8 @@ public final class PartnerConstants {
 	
 	public static final String PARTNER_DOMAIN_DEVICE = "DEVICE";
 
+	public static final String PARTNER_DOMAIN_MISP = "MISP";
+
     public static final String FTM = "ftm";
     
     public static final String GET_SIGNED_PARTNER_CERT_URL = "pmp.partner.original.certificate.get.rest.uri";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing MISP partner types.
  * MISP partners are now correctly assigned to the MISP domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->