### PR TITLE
Fix PR review comments: normalize additionalInfo default, license key…

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/misp/service/impl/InfraProviderServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/misp/service/impl/InfraProviderServiceImpl.java
@@ -615,7 +615,7 @@ public class InfraProviderServiceImpl implements InfraServiceProviderService {
 			entity.setMispLicenseId(UUID.randomUUID().toString());
 			entity.setMispId(partnerId);
 			entity.setLicenseKey(generateLicenseKey());
-			entity.setLicenseKeyName(licenseKeyName);
+			entity.setLicenseKeyName(PartnerUtil.trimAndReplace(licenseKeyName));
 			entity.setValidFromDate(LocalDateTime.now(ZoneId.of("UTC")));
 			LocalTime currentUtcTime = LocalTime.now(ZoneOffset.UTC);
 			entity.setValidToDate(LocalDateTime.of(expiryDate, currentUtcTime));

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/service/impl/PartnerServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/service/impl/PartnerServiceImpl.java
@@ -596,7 +596,7 @@ public class PartnerServiceImpl implements PartnerService {
 		}
 		partner.setAddress(keyManagerHelper.encryptData(partnerUpdateRequest.getAddress()));
 		partner.setContactNo(keyManagerHelper.encryptData(partnerUpdateRequest.getContactNumber()));
-		partner.setAdditionalInfo(partnerUpdateRequest.getAdditionalInfo()== null ? "[]" : partnerUpdateRequest.getAdditionalInfo().toString());
+		partner.setAdditionalInfo(partnerUpdateRequest.getAdditionalInfo() == null ? null : partnerUpdateRequest.getAdditionalInfo().toString());
 		partner.setLogoUrl(partnerUpdateRequest.getLogoUrl());
 		partner.setUpdBy(getLoggedInUserId());
 		partner.setUpdDtimes(Timestamp.valueOf(LocalDateTime.now()));

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/tasklets/MispLicenseExpiryAutoDeactivationTasklet.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/tasklets/MispLicenseExpiryAutoDeactivationTasklet.java
@@ -87,10 +87,10 @@ public class MispLicenseExpiryAutoDeactivationTasklet implements Tasklet {
                         webSubPublisher.notify(EventType.MISP_LICENSE_UPDATED, data, type);
 
                         deactivatedCount++;
-                        log.info("Deactivated expired MISP License key with id {} for misp id : {}", mispLicenseDetails.getLicenseKey(), mispLicenseDetails.getMispId());
+                        log.info("Deactivated expired MISP License key with id {} for misp id : {}", mispLicenseDetails.getMispLicenseId(), mispLicenseDetails.getMispId());
                     }
                 } catch(Exception e){
-                    log.error("Error deactivating MISP License key with id {} for misp id {}: {}", mispLicenseDetails.getLicenseKey(), mispLicenseDetails.getMispId(), e.getMessage());
+                    log.error("Error deactivating MISP License key with id {} for misp id {}: {}", mispLicenseDetails.getMispLicenseId(), mispLicenseDetails.getMispId(), e.getMessage());
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
… name, and license key logging

- Default additionalInfo to null on update path to match create path
- Normalize licenseKeyName before persisting to match duplicate-check query
- Log MISP license id instead of the raw license key secret