### PR TITLE
#2009: Fix null-pointer risks in client name map and email validation

### DIFF
--- a/partner/partner-management-service/src/main/java/io/mosip/pms/oauth/client/service/impl/ClientManagementServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/oauth/client/service/impl/ClientManagementServiceImpl.java
@@ -801,7 +801,10 @@ public class ClientManagementServiceImpl implements ClientManagementService {
 	}
 	
     private String getClientNameLanguageMapAsJsonString(Map<String, String> clientNameMap, String clientName) {
-        clientNameMap.put(NONE_LANG_KEY, clientName);
+		if (clientNameMap == null) {
+			clientNameMap = new HashMap<>();
+		}
+		clientNameMap.put(NONE_LANG_KEY, clientName);
         JSONObject clientNameObject = new JSONObject(clientNameMap);
         return clientNameObject.toString();
     }

--- a/partner/partner-management-service/src/main/java/io/mosip/pms/partner/service/impl/PartnerServiceImpl.java
+++ b/partner/partner-management-service/src/main/java/io/mosip/pms/partner/service/impl/PartnerServiceImpl.java
@@ -526,7 +526,7 @@ public class PartnerServiceImpl implements PartnerService {
 	 * @param emailId
 	 */
 	private boolean validateEmail(String emailId) {
-		if (!emailId.matches(emailRegex)) {
+		if (emailId == null || !emailId.matches(emailRegex)) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Guard against a null clientNameLangMap in getClientNameLanguageMapAsJsonString and a null emailId in validateEmail, both of which are optional/nullable inputs from request payloads.