### PR TITLE
#2017: Upgrade kernel dependencies to 1.2.0.2

### DIFF
--- a/partner/partner-management-service/pom.xml
+++ b/partner/partner-management-service/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>io.mosip.kernel</groupId>
 			<artifactId>kernel-openid-bridge-api</artifactId>
-			<version>1.2.0.1</version>
+			<version>1.2.0.2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -89,7 +89,7 @@
 		<dependency>
 			<groupId>io.mosip.kernel</groupId>
 			<artifactId>kernel-authcodeflowproxy-api</artifactId>
-			<version>1.2.0.1-B1</version>
+			<version>1.2.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.nimbusds</groupId>

--- a/partner/pms-common/pom.xml
+++ b/partner/pms-common/pom.xml
@@ -21,7 +21,7 @@
   	   <dependency>
 			<groupId>io.mosip.kernel</groupId>
 			<artifactId>kernel-openid-bridge-api</artifactId>
-			<version>1.2.0.1</version>
+			<version>1.2.0.2</version>
 			<scope>provided</scope>
 		</dependency>
   		<dependency>

--- a/partner/policy-management-service/pom.xml
+++ b/partner/policy-management-service/pom.xml
@@ -16,7 +16,7 @@
 	   <dependency>
 			<groupId>io.mosip.kernel</groupId>
 			<artifactId>kernel-openid-bridge-api</artifactId>
-			<version>1.2.0.1</version>
+			<version>1.2.0.2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/partner/pom.xml
+++ b/partner/pom.xml
@@ -69,16 +69,16 @@
 	<properties>
 		<kernel.version>1.2.0.2</kernel.version>
 		<kernel-dataaccess-hibernate.version>1.2.0.2</kernel-dataaccess-hibernate.version>
-		<kernel-websubclient-api.version>1.2.0.1</kernel-websubclient-api.version>
+		<kernel-websubclient-api.version>1.2.0.2</kernel-websubclient-api.version>
 		<kernel.templatemanager.velocity.version>1.2.0.2</kernel.templatemanager.velocity.version>
-		<kernel.authadapter.version>1.2.0.1</kernel.authadapter.version>
+		<kernel.authadapter.version>1.2.0.2</kernel.authadapter.version>
 		<maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
 		<maven.war.plugin.version>3.1.0</maven.war.plugin.version>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.version>3.8.0</maven.compiler.version>
 		<junit.version>4.12</junit.version>
-		<lombok.version>1.18.8</lombok.version>
+		<lombok.version>1.18.30</lombok.version>
 		<doclint>none</doclint>		
 		<maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
 		<maven.jacoco.version>0.8.5</maven.jacoco.version>
@@ -89,7 +89,7 @@
 		**io/mosip/pms/service/**,**/pms/authdevice/**,**/pms/device/validator/**,**/pms/device/util/**,**/entity/**,**/exception/**,**/util/**,**/keycloak/**/**,**/SwaggerConfig.java,**/PmpPolicyApplication.java,**/job/**
 		</sonar.coverage.exclusions>
 		<spring.boot.version>2.0.2.RELEASE</spring.boot.version>
-		<kernel-auth-adapter.version>1.2.0.1</kernel-auth-adapter.version>
+		<kernel-auth-adapter.version>1.2.0.2</kernel-auth-adapter.version>
 		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
 	</properties>
 	

--- a/partner/pom.xml
+++ b/partner/pom.xml
@@ -67,10 +67,10 @@
 	</distributionManagement>	
 
 	<properties>
-		<kernel.version>1.2.0.1</kernel.version>
-		<kernel-dataaccess-hibernate.version>1.2.0.1</kernel-dataaccess-hibernate.version>
+		<kernel.version>1.2.0.2</kernel.version>
+		<kernel-dataaccess-hibernate.version>1.2.0.2</kernel-dataaccess-hibernate.version>
 		<kernel-websubclient-api.version>1.2.0.1</kernel-websubclient-api.version>
-		<kernel.templatemanager.velocity.version>1.2.0.1</kernel.templatemanager.velocity.version>
+		<kernel.templatemanager.velocity.version>1.2.0.2</kernel.templatemanager.velocity.version>
 		<kernel.authadapter.version>1.2.0.1</kernel.authadapter.version>
 		<maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
 		<maven.war.plugin.version>3.1.0</maven.war.plugin.version>


### PR DESCRIPTION
Bump kernel-core, kernel-dataaccess-hibernate and
kernel-templatemanager-velocity to 1.2.0.2, the latest Java 11 tag published by mosip/commons. kernel-websubclient-api and kernel-auth-adapter remain at 1.2.0.1 since no 1.2.0.2 artifact is published for them on Maven Central yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to the latest patch releases.
  * Upgraded Lombok to improve compatibility and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->